### PR TITLE
Addmerger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ modules/writeDigitizerToRoot.cpp
 modules/writeHitDigiToRoot.cpp
 modules/writeHitDigiToHDF5.cpp
 modules/WfmReader.cpp
+src/trackMerger.cpp
 modules/printSimReader.cpp)
 target_link_libraries(ReconModules QTNMTools HighFive ${ROOT_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,10 @@ modules/printSimReader.cpp)
 target_link_libraries(ReconModules QTNMTools HighFive ${ROOT_LIBRARIES})
 
 # Build apps and examples
+add_executable(minantrecon.exe apps/minimalFirstStepRecon.cpp)
+target_link_libraries(minantrecon.exe PUBLIC ReconModules QTNMTools)
+add_executable(minnoantrecon.exe apps/minimalNoAntennaRecon.cpp)
+target_link_libraries(minnoantrecon.exe PUBLIC ReconModules QTNMTools)
 add_executable(antrecon.exe apps/antennaSimRecon.cpp)
 target_link_libraries(antrecon.exe PUBLIC ReconModules QTNMTools)
 add_executable(noantrecon.exe apps/noAntennaSimRecon.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ target_link_libraries(antreconHDF5.exe PUBLIC ReconModules QTNMTools)
 add_executable(noantreconHDF5.exe apps/noAntennaSimReconToHDF5.cpp)
 target_link_libraries(noantreconHDF5.exe PUBLIC ReconModules QTNMTools)
 
-add_executable(testG4out.exe apps/examples/testfakeG4_ToRoot.cpp)
+add_executable(testG4out.exe apps/examples/test_fakeG4_ToRoot.cpp)
 target_link_libraries(testG4out.exe PUBLIC ReconModules QTNMTools)
 add_executable(exwrhdf5.exe apps/examples/example_write_hdf5.cpp)
 target_link_libraries(exwrhdf5.exe PUBLIC ReconModules QTNMTools)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,8 @@ modules/WaveformSampling.cpp
 modules/AddNoise.cpp
 modules/Mixer.cpp
 modules/Digitize.cpp
+modules/TestG4AntGenerator.cpp
+modules/FakeG4AntWriter.cpp
 modules/writeWfmToRoot.cpp
 modules/writeDigitizerToRoot.cpp
 modules/writeHitDigiToRoot.cpp
@@ -87,6 +89,8 @@ target_link_libraries(antreconHDF5.exe PUBLIC ReconModules QTNMTools)
 add_executable(noantreconHDF5.exe apps/noAntennaSimReconToHDF5.cpp)
 target_link_libraries(noantreconHDF5.exe PUBLIC ReconModules QTNMTools)
 
+add_executable(testG4out.exe apps/examples/testfakeG4_ToRoot.cpp)
+target_link_libraries(testG4out.exe PUBLIC ReconModules QTNMTools)
 add_executable(exwrhdf5.exe apps/examples/example_write_hdf5.cpp)
 target_link_libraries(exwrhdf5.exe PUBLIC ReconModules QTNMTools)
 add_executable(exhdwrite.exe apps/examples/example_hitdigi_write.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,9 +64,11 @@ modules/WaveformSampling.cpp
 modules/AddNoise.cpp
 modules/Mixer.cpp
 modules/Digitize.cpp
+modules/writeWfmToRoot.cpp
 modules/writeDigitizerToRoot.cpp
 modules/writeHitDigiToRoot.cpp
 modules/writeHitDigiToHDF5.cpp
+modules/WfmReader.cpp
 modules/printSimReader.cpp)
 target_link_libraries(ReconModules QTNMTools HighFive ${ROOT_LIBRARIES})
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ i.e. a reconstruction pipeline code. There are currently 2 apps in the apps fold
 to use the pipeline in the apps/examples folder. The tools are considered fairly complete, and they would be used in modules which
 are meant to run in the pipeline. The modules folder holds examples for a few of the tools as well as
 examples for reader modules (sources) and pipeline sinks like a writer or a print to screen.
+Update: with the simulation now including secondary electron production, several waveforms could result
+for a single event. The reconstruction should be able to merge them into one before adding noise and
+subsequent operations, i.e. a track combining module should be present for that step, with appropriate
+addition of waveforms under suitable conditions, e.g sufficient kinetic energy such that a waveform of 
+interest is added.
 
 The cmake file builds all the individual little test codes from the examples folder. These should demonstrate
 the proper functioning of individual tools, at least for the case considered in the example code. They

--- a/apps/antennaSimRecon.cpp
+++ b/apps/antennaSimRecon.cpp
@@ -16,10 +16,6 @@
 #include "TFile.h"
 #include "TTree.h"
 #include "TTreeReader.h"
-#include "Math/Vector3D.h" // XYZVector
-#include "Math/Point3D.h" // XYZPoint
-
-using namespace ROOT::Math;
 
 // us
 #include "yap/pipeline.h"
@@ -34,7 +30,6 @@ using namespace ROOT::Math;
 
 #include "CLI11.hpp"
 #include <Event.hh>
-#include "types.hh"
 #include <mp-units/format.h>
 #include <mp-units/ostream.h>
 

--- a/apps/antennaSimReconToHDF5.cpp
+++ b/apps/antennaSimReconToHDF5.cpp
@@ -33,7 +33,6 @@
 
 #include "CLI11.hpp"
 #include <Event.hh>
-#include "types.hh"
 #include <mp-units/format.h>
 #include <mp-units/ostream.h>
 

--- a/apps/examples/test_fakeG4_ToRoot.cpp
+++ b/apps/examples/test_fakeG4_ToRoot.cpp
@@ -49,10 +49,10 @@ int main(int argc, char** argv)
   source.setPhase_rad(ph);
 
   // data sink: write to Root, take from key
-  TFile* outfile = new TFile(outfname.data(), "RECREATE");
+  TFile* outfile = new TFile(fname.data(), "RECREATE");
   TTree* tr = new TTree("test","test data");
   tr->SetDirectory(outfile);
-  auto sink = ("wave", tr);
+  auto sink = FakeG4AntToRoot("wave", tr);
   
   auto pl = yap::Pipeline{} | source | sink;
   

--- a/apps/examples/test_fakeG4_ToRoot.cpp
+++ b/apps/examples/test_fakeG4_ToRoot.cpp
@@ -1,0 +1,64 @@
+// example application
+// how to run a reconstruction pipeline
+// make a main program, include and instantiate all the modules
+// as required for the intended purpose and send them
+// into the pipeline object.
+// Needs a data source and a data sink at the least.
+// Any data processing needs to be placed in between these bookends.
+//
+// Current data model assumes the exchange of a DataPack from module to module
+// with the definition in Event.hh
+
+// std
+#include<iostream>
+#include<string>
+
+// ROOT
+#include "TFile.h"
+#include "TTree.h"
+
+// us
+#include "yap/pipeline.h"
+#include "modules/TestG4AntGenerator.hh"
+#include "modules/FakeG4AntWriter.hh"
+#include "CLI11.hpp"
+
+int main(int argc, char** argv)
+{
+      // command line interface
+  CLI::App app{"Example Recon Pipeline"};
+  std::string fname = "testG4.root";
+
+  app.add_option("-o,--output", fname, "<output file name> Default: testG4.root");
+
+  CLI11_PARSE(app, argc, argv);
+
+  // data source: sine signal generator, store under key 'wave'
+  quantity<V> amp = 1.0 * V;
+  quantity<Hz> srate = 155.0 * GHz;
+  quantity<s>  dur = 1.0 * ns;
+  quantity<Hz> freq = 20.0 * GHz;
+  quantity<rad> ph = 0.0 * deg;
+
+  auto source = TestG4AntGenerator("wave");
+  source.setNAntenna(2);
+  source.setAmplitude(amp);
+  source.setFrequency(freq);
+  source.setSampling_rate(srate);
+  source.setDuration(dur);
+  source.setPhase_rad(ph);
+
+  // data sink: write to Root, take from key
+  TFile* outfile = new TFile(outfname.data(), "RECREATE");
+  TTree* tr = new TTree("test","test data");
+  tr->SetDirectory(outfile);
+  auto sink = ("wave", tr);
+  
+  auto pl = yap::Pipeline{} | source | sink;
+  
+  pl.consume();
+
+  std::cout << "in app: " << std::endl;
+  tr->Write();
+  outfile->Close(); // free TTree
+}

--- a/apps/minimalFirstStepRecon.cpp
+++ b/apps/minimalFirstStepRecon.cpp
@@ -16,10 +16,6 @@
 #include "TFile.h"
 #include "TTree.h"
 #include "TTreeReader.h"
-#include "Math/Vector3D.h" // XYZVector
-#include "Math/Point3D.h" // XYZPoint
-
-using namespace ROOT::Math;
 
 // us
 #include "yap/pipeline.h"

--- a/apps/minimalFirstStepRecon.cpp
+++ b/apps/minimalFirstStepRecon.cpp
@@ -1,0 +1,92 @@
+// example application
+// how to run a reconstruction pipeline
+// make a main program, include and instantiate all the modules
+// as required for the intended purpose and send them
+// into the pipeline object.
+// Needs a data source and a data sink at the least.
+// Any data processing needs to be placed in between these bookends.
+//
+
+// std
+#include<iostream>
+#include<string>
+#include<vector>
+
+// ROOT
+#include "TFile.h"
+#include "TTree.h"
+#include "TTreeReader.h"
+#include "Math/Vector3D.h" // XYZVector
+#include "Math/Point3D.h" // XYZPoint
+
+using namespace ROOT::Math;
+
+// us
+#include "yap/pipeline.h"
+#include "modules/FullAntennaSimReader.hh"
+#include "modules/AddChirpToTruth.hh"
+#include "modules/WaveformSampling.hh"
+#include "modules/OmegaBeatToTruth.hh"
+#include "modules/writeWfmToRoot.hh"
+
+#include "CLI11.hpp"
+#include <Event.hh>
+#include <mp-units/format.h>
+#include <mp-units/ostream.h>
+
+
+int main(int argc, char** argv)
+{
+      // command line interface
+  CLI::App app{"Minimal First Step Recon Pipeline"};
+  int nevents = -1;
+  quantity<T> bfield = 0.7 * T; // constant sim b-field value [T]
+  std::string fname = "qtnm.root";
+  std::string outfname = "sampled.root";
+
+  app.add_option("-n,--nevents", nevents, "<number of events> Default: -1");
+  app.add_option("-i,--input", fname, "<input file name> Default: qtnm.root");
+  app.add_option("-o,--output", outfname, "<output file name> Default: sampled.root");
+
+  CLI11_PARSE(app, argc, argv);
+
+  // keys to set
+  std::string origin = "raw";
+  std::string samp = "sampled";
+
+  // data source: read from ROOT file, store under key 'raw'
+  TFile ff(fname.data(),"READ");
+  TTreeReader re1("ntuple/Signal", &ff);
+  TTreeReader re2("ntuple/Score", &ff);
+  auto source = FullAntennaSimReader(re1, re2, origin);
+  source.setMaxEventNumber(nevents); // default = all events in file
+  source.setSimConstantBField(bfield); // MUST be set
+
+  // add truth
+  auto addchirp = AddChirpToTruth(origin); // default antenna number
+  int nant = 2;
+  addchirp.setAntennaNumber(nant);
+  
+  // transformer (2)
+  auto interpolator = WaveformSampling(origin,"",samp);
+  quantity<ns> stime = 0.008 * ns;
+  interpolator.setSampleTime(stime);
+
+  // add truth, 'omout' is just for checking
+  auto addbeat = OmegaBeatToTruth(samp,"omout");
+
+  // data sink: write to Root, take from key
+  TFile* outfile = new TFile(outfname.data(), "RECREATE");
+  TTree* tr = new TTree("sampled","sampled data");
+  tr->SetDirectory(outfile);
+  auto sink = WriterWfmToRoot(samp, tr, nant);
+  
+  auto pl = yap::Pipeline{} | source | addchirp | interpolator | addbeat | sink;
+  
+  pl.consume();
+  
+  std::cout << "app finished. " << std::endl;
+  tr->Write();
+  outfile->Close(); // free TTree
+  ff.Close();
+}

--- a/apps/minimalNoAntennaRecon.cpp
+++ b/apps/minimalNoAntennaRecon.cpp
@@ -33,7 +33,6 @@ using namespace ROOT::Math;
 
 #include "CLI11.hpp"
 #include <Event.hh>
-#include "types.hh"
 #include <mp-units/format.h>
 #include <mp-units/ostream.h>
 

--- a/apps/minimalNoAntennaRecon.cpp
+++ b/apps/minimalNoAntennaRecon.cpp
@@ -1,0 +1,114 @@
+// example application
+// how to run a reconstruction pipeline
+// make a main program, include and instantiate all the modules
+// as required for the intended purpose and send them
+// into the pipeline object.
+// Needs a data source and a data sink at the least.
+// Any data processing needs to be placed in between these bookends.
+//
+
+// std
+#include<iostream>
+#include<string>
+#include<vector>
+
+// ROOT
+#include "TFile.h"
+#include "TTree.h"
+#include "TTreeReader.h"
+#include "Math/Vector3D.h" // XYZVector
+#include "Math/Point3D.h" // XYZPoint
+
+using namespace ROOT::Math;
+
+// us
+#include "yap/pipeline.h"
+#include "modules/FullKinematicsSimReader.hh"
+#include "modules/AddChirpToTruth.hh"
+#include "modules/AntennaResponse.hh"
+#include "receiver/HalfWaveDipole.hh"
+#include "modules/WaveformSampling.hh"
+#include "modules/OmegaBeatToTruth.hh"
+#include "modules/writeWfmToRoot.hh"
+
+#include "CLI11.hpp"
+#include <Event.hh>
+#include "types.hh"
+#include <mp-units/format.h>
+#include <mp-units/ostream.h>
+
+
+int main(int argc, char** argv)
+{
+      // command line interface
+  CLI::App app{"Minimal First Step Recon Pipeline"};
+  int nevents = -1;
+  quantity<T> bfield = 0.7 * T; // constant sim b-field value [T]
+  std::string fname = "qtnm.root";
+  std::string outfname = "sampled.root";
+
+  app.add_option("-n,--nevents", nevents, "<number of events> Default: -1");
+  app.add_option("-i,--input", fname, "<input file name> Default: qtnm.root");
+  app.add_option("-o,--output", outfname, "<output file name> Default: sampled.root");
+
+  CLI11_PARSE(app, argc, argv);
+
+  // keys to set
+  std::string origin = "raw";
+  std::string resp = "response";
+  std::string samp = "sampled";
+
+  // data source: read from ROOT file, store under key 'raw'
+  TFile ff(fname.data(),"READ");
+  TTreeReader re1("ntuple/Signal", &ff);
+  TTreeReader re2("ntuple/Score", &ff);
+  auto source = FullKinematicsSimReader(re1, re2, origin);
+  source.setMaxEventNumber(nevents); // default = all events in file
+  source.setSimConstantBField(bfield); // MUST be set
+
+  // add truth
+  auto addchirp = AddChirpToTruth(origin); // default antenna number
+
+  // transformer (1)
+  int nant = 2;
+  auto antresponse = AntennaResponse(origin, resp);
+  // configure antennae
+  std::vector<VReceiver*> allantenna;
+  XYZPoint  apos1(0.027, 0.0, 0.0); // fix from geometry, SI unit [m]
+  XYZVector apol1(0.0, 1.0, 0.0); // unit vector
+  VReceiver* ant1 = new HalfWaveDipole(apos1, apol1); // insert as pointer
+  allantenna.push_back(ant1);
+  XYZPoint  apos2(0.0, 0.027, 0.0); // fix from geometry
+  XYZVector apol2(1.0, 0.0, 0.0); // unit vector
+  VReceiver* ant2 = new HalfWaveDipole(apos2, apol2); // insert as pointer
+  allantenna.push_back(ant2);
+
+  antresponse.setAntennaCollection(allantenna); // finished antenna configuration
+
+  // transformer (2)
+  auto interpolator = WaveformSampling(origin,resp,samp);
+  quantity<ns> stime = 0.008 * ns;
+  interpolator.setSampleTime(stime);
+
+  // add truth, 'omout' is just for checking
+  auto addbeat = OmegaBeatToTruth(samp,"omout");
+
+  // data sink
+  TFile* outfile = new TFile(outfname.data(), "RECREATE");
+  TTree* tr = new TTree("sampled","sampled data");
+  tr->SetDirectory(outfile);
+  auto sink = WriterWfmToRoot(samp, tr, nant);
+  
+  auto pl = yap::Pipeline{} | source | addchirp | antresponse | interpolator | addbeat |
+    sink;
+  
+  pl.consume();
+  
+  std::cout << "app finished. " << std::endl;
+  tr->Write();
+  outfile->Close(); // free TTree
+  ff.Close();
+
+  delete ant1;
+  delete ant2;
+}

--- a/apps/noAntennaSimRecon.cpp
+++ b/apps/noAntennaSimRecon.cpp
@@ -36,7 +36,6 @@ using namespace ROOT::Math;
 
 #include "CLI11.hpp"
 #include <Event.hh>
-#include "types.hh"
 #include <mp-units/format.h>
 #include <mp-units/ostream.h>
 

--- a/apps/noAntennaSimReconToHDF5.cpp
+++ b/apps/noAntennaSimReconToHDF5.cpp
@@ -39,7 +39,6 @@ using namespace ROOT::Math;
 
 #include "CLI11.hpp"
 #include <Event.hh>
-#include "types.hh"
 #include <mp-units/format.h>
 #include <mp-units/ostream.h>
 

--- a/include/DownConverter.hh
+++ b/include/DownConverter.hh
@@ -1,12 +1,12 @@
 // Down-converting Mixer for QTNM tools
+#ifndef QT_DCONV_H
+#define QT_DCONV_H
 
 // us
 #include "types.hh"
 #include "filter.hh"
 #include "SineGenerator.hh"
 
-#ifndef QT_DCONV_H
-#define QT_DCONV_H
 
 class DownConverter
 {

--- a/include/Event.hh
+++ b/include/Event.hh
@@ -36,6 +36,7 @@ struct truth_t {
   double snratio; // from adding noise
   quantity<T> bfield;
   quantity<ns> sampling_time; // from sampling
+  quantity<ns> start_time;    // from time vector for each trackID
   quantity<Hz> average_omega; // from antenna
   quantity<Hz> beat_frequency; // from omega vector
   quantity<Hz/s> chirp_rate;

--- a/include/Event.hh
+++ b/include/Event.hh
@@ -45,6 +45,7 @@ struct truth_t {
   struct vertex_t {
     int eventID;
     int trackID;
+    std::vector<int> trackHistory;
     quantity<m> posx, posy,posz; // turn no unit numbers from file
     quantity<eV> kineticenergy;  // into quantities with unit.
     quantity<deg> pitchangle;

--- a/include/LIA.hh
+++ b/include/LIA.hh
@@ -1,12 +1,11 @@
 // Lock-in Amplifier (LIA) for QTNM tools
 // operating in quadrature only, no phase output
+#ifndef QT_LIA_H
+#define QT_LIA_H
 
 // us
 #include "types.hh"
 #include "filter.hh"
-
-#ifndef QT_LIA_H
-#define QT_LIA_H
 
 class LIA
 {

--- a/include/filter.hh
+++ b/include/filter.hh
@@ -1,13 +1,12 @@
 // Filter for QTNM tools
+#ifndef QT_FILTER_H
+#define QT_FILTER_H
 
 // std
 
 // us
 #include "types.hh"
 #include "dsp.hh"
-
-#ifndef QT_FILTER_H
-#define QT_FILTER_H
 
 
 class Butterworth

--- a/include/modules/FakeG4AntWriter.hh
+++ b/include/modules/FakeG4AntWriter.hh
@@ -31,11 +31,11 @@ class FakeG4AntToRoot
   std::string inkey;
   TTree* mytree;
 
-  std::vector<int> antennaID; // interleaved like G4 output
-  vec_t timevec; // may change in QTNMSim to non-interleaved vector
-  vec_t voltagevec;
-  vec_t KEdummy; // empty for consistency with reader 
-  vec_t OMdummy; // empty
+  std::vector<int>* antennaID; // interleaved like G4 output
+  vec_t* timevec; // may change in QTNMSim to non-interleaved vector
+  vec_t* voltagevec;
+  vec_t* KEdummy; // empty for consistency with reader 
+  vec_t* OMdummy; // empty
   // doubles/int for values without unit
   int evID, trID;
   // no fake vertex

--- a/include/modules/FakeG4AntWriter.hh
+++ b/include/modules/FakeG4AntWriter.hh
@@ -1,0 +1,45 @@
+// ROOT fake Geant4 Antenna Sim writer for a pipeline module
+
+#ifndef writerFG4_HH
+#define writerFG4_HH 1
+
+// std includes
+#include <string>
+#include <vector>
+
+// ROOT
+#include "TTree.h"
+
+// must have include for pipeline
+#include <Event.hh>
+
+class FakeG4AntToRoot
+{
+    public:
+  FakeG4AntToRoot(std::string in, TTree* tr); // constructor; required
+  // Configures the module. Could have more config parameters
+  // Minimum required are the key labels for input and output 
+  // of Event Map data item.
+
+  void operator()(DataPack dp); // this is called by the pipeline
+  // Writers/Sinks only receive a DataPack and return void as signature.
+
+  // getter/setter methods for configuration could live here.
+
+    private:
+  // include any configuration data members for internal use here.
+  std::string inkey;
+  TTree* mytree;
+
+  std::vector<int> antennaID; // interleaved like G4 output
+  vec_t timevec; // may change in QTNMSim to non-interleaved vector
+  vec_t voltagevec;
+  vec_t KEdummy; // empty for consistency with reader 
+  vec_t OMdummy; // empty
+  // doubles/int for values without unit
+  int evID, trID;
+  // no fake vertex
+  double dx, dy, dz, dke, dang; // empty dummy numbers for reader
+  // no hits in this fake writer
+};
+#endif

--- a/include/modules/TestG4AntGenerator.hh
+++ b/include/modules/TestG4AntGenerator.hh
@@ -1,0 +1,47 @@
+// Sine signal generator for a pipeline module
+#ifndef testG4generator_HH
+#define testG4generator_HH 1
+
+// std includes
+#include <string>
+
+// tool includes
+
+// must have include for pipeline
+#include <Event.hh>
+#include "SineGenerator.hh"
+
+class TestG4AntGenerator
+{
+public:
+  TestG4AntGenerator(std::string outbox); // constructor; required
+  // Configures the module. Could have more config parameters
+  // String Key outbox label as input.
+  
+  DataPack operator()(); // this is called by the pipeline
+  // Generators deliver an event map and receive nothing as signature.
+  
+  // getter/setter methods for configuration could live here.
+  inline void setNAntennna(int na) {nantenna = na;}
+  inline void setAmplitude(quantity<V>  a) {amplitude = a;}
+  inline void setFrequency(quantity<Hz> ff) {frequency = ff;}
+  inline void setSampling_rate(quantity<Hz> sr) {sampling_rate = sr;}
+  inline void setDuration(quantity<s> d) {duration = d;}
+  inline void setPhase_rad(quantity<rad> phr) {phase = phr;}
+  
+private:
+  // include any configuration data members for internal use here.
+  int nantenna;
+  quantity<V>   amplitude;
+  quantity<Hz>  frequency;
+  quantity<Hz>  sampling_rate;
+  quantity<s>   duration;
+  quantity<rad> phase;
+  SineGenerator sig; // default constructor
+  
+  // these below serve as string keys to access (read/write) the Event map
+  std::string outkey;
+  int counter;
+  int maxEventNumber; // hard-coded for test operation
+};
+#endif

--- a/include/modules/TestG4AntGenerator.hh
+++ b/include/modules/TestG4AntGenerator.hh
@@ -22,7 +22,7 @@ public:
   // Generators deliver an event map and receive nothing as signature.
   
   // getter/setter methods for configuration could live here.
-  inline void setNAntennna(int na) {nantenna = na;}
+  inline void setNAntenna(int na) {nantenna = na;}
   inline void setAmplitude(quantity<V>  a) {amplitude = a;}
   inline void setFrequency(quantity<Hz> ff) {frequency = ff;}
   inline void setSampling_rate(quantity<Hz> sr) {sampling_rate = sr;}

--- a/include/modules/TestG4AntGenerator.hh
+++ b/include/modules/TestG4AntGenerator.hh
@@ -31,7 +31,9 @@ public:
   
 private:
   // include any configuration data members for internal use here.
+  int eID;
   int nantenna;
+  int timeshift;
   quantity<V>   amplitude;
   quantity<Hz>  frequency;
   quantity<Hz>  sampling_rate;

--- a/include/modules/WfmReader.hh
+++ b/include/modules/WfmReader.hh
@@ -25,25 +25,31 @@ class WfmReader
     // ROOT file access for member functions
     TTreeReader& reader;
 
-    TTreeReaderValue<int> eventID;
-    TTreeReaderValue<int> trackID;
-    TTreeReaderValue<int> hitevID;
-    TTreeReaderValue<int> hittrID;
-    TTreeReaderValue<double> edep; // interaction data
-    TTreeReaderValue<double> tstamp;
-    TTreeReaderValue<double> prek;
-    TTreeReaderValue<double> postk;
-    TTreeReaderValue<double> preth;
-    TTreeReaderValue<double> postth;
-    TTreeReaderValue<double> locx; // interaction location
-    TTreeReaderValue<double> locy;
-    TTreeReaderValue<double> locz;
-    TTreeReaderValue<double> posx; // vertex data
-    TTreeReaderValue<double> posy;
-    TTreeReaderValue<double> posz;
-    TTreeReaderValue<double> kine;
-    TTreeReaderValue<double> pangle;
-    TTreeReaderValue<std::vector<vec_t*>> wfmvec;
+  TTreeReaderValue<int> nantenna;
+  TTreeReaderValue<int> eventID;
+  TTreeReaderValue<int> trackID;
+  TTreeReaderValue<double> samplingtime;
+  TTreeReaderValue<double> avomega;
+  TTreeReaderValue<double> beatf;
+  TTreeReaderValue<double> chirprate;
+  TTreeReaderValue<double> bfield;
+  // vertex
+  TTreeReaderValue<double> posx;
+  TTreeReaderValue<double> posy;
+  TTreeReaderValue<double> posz;
+  TTreeReaderValue<double> kEnergy;
+  TTreeReaderValue<double> pangle;
+  // hit data
+  TTreeReaderValue<std::vector<int>> hitevID;
+  TTreeReaderValue<std::vector<int>> hittrID;
+  TTreeReaderValue<std::vector<double>> hitedep; // interaction data
+  TTreeReaderValue<std::vector<double>> hittime;
+  TTreeReaderValue<std::vector<double>> hitposttheta;
+  TTreeReaderValue<std::vector<double>> hitx; // interaction location
+  TTreeReaderValue<std::vector<double>> hity;
+  TTreeReaderValue<std::vector<double>> hitz;
+  TTreeReaderValue<vec_t> wfm;
+  std::vector<TTreeReaderValue<vec_t>> wfmvec;
 
     // these below serve as string keys to access (read/write) the Event map
     std::string outkey;

--- a/include/modules/WfmReader.hh
+++ b/include/modules/WfmReader.hh
@@ -7,24 +7,25 @@
 
 // ROOT
 #include "TTreeReader.h"
+#include "TTreeReaderValue.h"
+#include "TTreeReaderArray.h"
 
 // must have include for pipeline
 #include <Event.hh>
-#include "types.hh"
 
 class WfmReader
 {
-    public:
-        WfmReader(TTreeReader& re, std::string outbox); // constructor; required
-        // input file name and new Key outbox label.
+public:
+  WfmReader(TTreeReader& re, int na, std::string outbox); // constructor; required
+  // input file name and new Key outbox label.
 
-        DataPack operator()(); // this is called by the pipeline
+  DataPack operator()(); // this is called by the pipeline
 
-    private:
-    // include any configuration data members for internal use here.
-    // ROOT file access for member functions
-    TTreeReader& reader;
-
+private:
+  // include any configuration data members for internal use here.
+  // ROOT file access for member functions
+  TTreeReader& reader;
+  
   TTreeReaderValue<int> nantenna;
   TTreeReaderValue<int> eventID;
   TTreeReaderValue<int> trackID;
@@ -48,11 +49,12 @@ class WfmReader
   TTreeReaderValue<std::vector<double>> hitx; // interaction location
   TTreeReaderValue<std::vector<double>> hity;
   TTreeReaderValue<std::vector<double>> hitz;
-  TTreeReaderValue<vec_t> wfm;
-  std::vector<TTreeReaderValue<vec_t>> wfmvec;
+  // waveform data
+  std::vector<double> wfm;
+  std::vector<TTreeReaderArray<double>> wfmarray;
 
-    // these below serve as string keys to access (read/write) the Event map
-    std::string outkey;
-
+  // these below serve as string keys to access (read/write) the Event map
+  std::string outkey;
+  int nant; // configure at construction
 };
 #endif

--- a/include/modules/WfmReader.hh
+++ b/include/modules/WfmReader.hh
@@ -50,7 +50,6 @@ private:
   TTreeReaderValue<std::vector<double>> hity;
   TTreeReaderValue<std::vector<double>> hitz;
   // waveform data
-  std::vector<double> wfm;
   std::vector<TTreeReaderArray<double>> wfmarray;
 
   // these below serve as string keys to access (read/write) the Event map

--- a/include/modules/WfmReader.hh
+++ b/include/modules/WfmReader.hh
@@ -30,6 +30,7 @@ private:
   TTreeReaderValue<int> eventID;
   TTreeReaderValue<int> trackID;
   TTreeReaderValue<double> samplingtime;
+  TTreeReaderValue<double> starttime;
   TTreeReaderValue<double> avomega;
   TTreeReaderValue<double> beatf;
   TTreeReaderValue<double> chirprate;

--- a/include/modules/WfmReader.hh
+++ b/include/modules/WfmReader.hh
@@ -1,0 +1,52 @@
+// Intermediate waveform Reader for a pipeline module
+#ifndef wfmreader_HH
+#define wfmreader_HH 1
+
+// std includes
+#include <string>
+
+// ROOT
+#include "TTreeReader.h"
+
+// must have include for pipeline
+#include <Event.hh>
+#include "types.hh"
+
+class WfmReader
+{
+    public:
+        WfmReader(TTreeReader& re, std::string outbox); // constructor; required
+        // input file name and new Key outbox label.
+
+        DataPack operator()(); // this is called by the pipeline
+
+    private:
+    // include any configuration data members for internal use here.
+    // ROOT file access for member functions
+    TTreeReader& reader;
+
+    TTreeReaderValue<int> eventID;
+    TTreeReaderValue<int> trackID;
+    TTreeReaderValue<int> hitevID;
+    TTreeReaderValue<int> hittrID;
+    TTreeReaderValue<double> edep; // interaction data
+    TTreeReaderValue<double> tstamp;
+    TTreeReaderValue<double> prek;
+    TTreeReaderValue<double> postk;
+    TTreeReaderValue<double> preth;
+    TTreeReaderValue<double> postth;
+    TTreeReaderValue<double> locx; // interaction location
+    TTreeReaderValue<double> locy;
+    TTreeReaderValue<double> locz;
+    TTreeReaderValue<double> posx; // vertex data
+    TTreeReaderValue<double> posy;
+    TTreeReaderValue<double> posz;
+    TTreeReaderValue<double> kine;
+    TTreeReaderValue<double> pangle;
+    TTreeReaderValue<std::vector<vec_t*>> wfmvec;
+
+    // these below serve as string keys to access (read/write) the Event map
+    std::string outkey;
+
+};
+#endif

--- a/include/modules/writeDigitizerToRoot.hh
+++ b/include/modules/writeDigitizerToRoot.hh
@@ -39,6 +39,7 @@ class WriterDigiToRoot
       int nant, evID, trID;
       double snratio;
       double samplingtime; // from quantity<ns>
+      double starttime; // from quantity<ns>
       double avomega; // quantity<Hz>
       double beatf; // quantity<Hz>
       double chirprate; // quantity<Hz/s>
@@ -48,6 +49,7 @@ class WriterDigiToRoot
       double posz; // quantity<m>
       double kEnergy; // quantity<eV>
       double pangle; // quantity<deg>
+      std::vector<int> trackHistory;
       // experiment
       double gain;
       double tfrequency; // quantity<Hz>

--- a/include/modules/writeHitDigiToHDF5.hh
+++ b/include/modules/writeHitDigiToHDF5.hh
@@ -30,6 +30,7 @@ class WriterHitDigiToHDF5
       int nant, evID, trID; // ID numbers for grouping
       bool bnew_event, bnew_sim;
 
+      std::vector<int> trackHistory;
       // hit data
       std::vector<int> hittrID;
       std::vector<double> hitx;

--- a/include/modules/writeHitDigiToRoot.hh
+++ b/include/modules/writeHitDigiToRoot.hh
@@ -39,6 +39,7 @@ class WriterHitDigiToRoot
       int nant, evID, trID;
       double snratio;
       double samplingtime; // from quantity<ns>
+      double starttime; // from quantity<ns>
       double avomega; // quantity<Hz>
       double beatf; // quantity<Hz>
       double chirprate; // quantity<Hz/s>
@@ -49,6 +50,7 @@ class WriterHitDigiToRoot
       double posz; // quantity<m>
       double kEnergy; // quantity<eV>
       double pangle; // quantity<deg>
+      std::vector<int> trackHistory;
       // experiment
       double gain;
       double tfrequency; // quantity<Hz>

--- a/include/modules/writeWfmToRoot.hh
+++ b/include/modules/writeWfmToRoot.hh
@@ -49,6 +49,7 @@ class WriterWfmToRoot
       double posz; // quantity<m>
       double kEnergy; // quantity<eV>
       double pangle; // quantity<deg>
+      std::vector<int> trackHistory;
       // hit data
       std::vector<int>* hitevID;
       std::vector<int>* hittrID;

--- a/include/modules/writeWfmToRoot.hh
+++ b/include/modules/writeWfmToRoot.hh
@@ -1,0 +1,60 @@
+// ROOT waveform writer for a pipeline module
+
+#ifndef writerWfm_HH
+#define writerWfm_HH 1
+
+// std includes
+#include <string>
+#include <vector>
+#include <array>
+
+// ROOT
+#include "TTree.h"
+
+// must have include for pipeline
+#include <Event.hh>
+
+class WriterWfmToRoot
+{
+    public:
+        WriterWfmToRoot(TTree* tr, int na); // constructor; required
+        // Need antenna number as input for setting up output file
+        // That truth data is in DataPack but not available at construction.
+        // Configures the module. Could have more config parameters
+        // Minimum required are the key labels for input and output 
+        // of Event Map data item.
+
+        void operator()(DataPack dp); // this is called by the pipeline
+        // Writers/Sinks only receive a DataPack and return void as signature.
+
+        // getter/setter methods for configuration could live here.
+
+    private:
+    // include any configuration data members for internal use here.
+      int nantenna; // needed for construction of output file
+      TTree* mytree;
+      std::vector<vec_t*> purewave; // no unit storage in ROOT file
+      // doubles/int for values without unit
+      int nant, evID, trID;
+      double samplingtime; // from quantity<ns>
+      double avomega; // quantity<Hz>
+      double beatf; // quantity<Hz>
+      double chirprate; // quantity<Hz/s>
+      double bfield; // quantity<T>
+      // vertex
+      double posx; // quantity<m>
+      double posy; // quantity<m>
+      double posz; // quantity<m>
+      double kEnergy; // quantity<eV>
+      double pangle; // quantity<deg>
+      // hit data
+      std::vector<int>* hitevID;
+      std::vector<int>* hittrID;
+      std::vector<double>* hitx;
+      std::vector<double>* hity;
+      std::vector<double>* hitz;
+      std::vector<double>* hitedep;
+      std::vector<double>* hittime;
+      std::vector<double>* hitposttheta;
+};
+#endif

--- a/include/modules/writeWfmToRoot.hh
+++ b/include/modules/writeWfmToRoot.hh
@@ -13,7 +13,6 @@
 
 // must have include for pipeline
 #include <Event.hh>
-#include "types.hh"
 
 class WriterWfmToRoot
 {

--- a/include/modules/writeWfmToRoot.hh
+++ b/include/modules/writeWfmToRoot.hh
@@ -38,6 +38,7 @@ class WriterWfmToRoot
       // doubles/int for values without unit
       int evID, trID;
       double samplingtime; // from quantity<ns>
+      double starttime; // from quantity<ns>
       double avomega; // quantity<Hz>
       double beatf; // quantity<Hz>
       double chirprate; // quantity<Hz/s>

--- a/include/modules/writeWfmToRoot.hh
+++ b/include/modules/writeWfmToRoot.hh
@@ -13,11 +13,12 @@
 
 // must have include for pipeline
 #include <Event.hh>
+#include "types.hh"
 
 class WriterWfmToRoot
 {
     public:
-        WriterWfmToRoot(TTree* tr, int na); // constructor; required
+  WriterWfmToRoot(std::string in, TTree* tr, int na); // constructor; required
         // Need antenna number as input for setting up output file
         // That truth data is in DataPack but not available at construction.
         // Configures the module. Could have more config parameters
@@ -31,6 +32,7 @@ class WriterWfmToRoot
 
     private:
     // include any configuration data members for internal use here.
+      std::string inkey;
       int nantenna; // needed for construction of output file
       TTree* mytree;
       std::vector<vec_t*> purewave; // no unit storage in ROOT file

--- a/include/modules/writeWfmToRoot.hh
+++ b/include/modules/writeWfmToRoot.hh
@@ -49,7 +49,7 @@ class WriterWfmToRoot
       double posz; // quantity<m>
       double kEnergy; // quantity<eV>
       double pangle; // quantity<deg>
-      std::vector<int> trackHistory;
+      std::vector<int>* trackHistory;
       // hit data
       std::vector<int>* hitevID;
       std::vector<int>* hittrID;

--- a/include/modules/writeWfmToRoot.hh
+++ b/include/modules/writeWfmToRoot.hh
@@ -37,7 +37,7 @@ class WriterWfmToRoot
       TTree* mytree;
       std::vector<vec_t*> purewave; // no unit storage in ROOT file
       // doubles/int for values without unit
-      int nant, evID, trID;
+      int evID, trID;
       double samplingtime; // from quantity<ns>
       double avomega; // quantity<Hz>
       double beatf; // quantity<Hz>

--- a/include/signalgen/ChirpGenerator.hh
+++ b/include/signalgen/ChirpGenerator.hh
@@ -1,12 +1,12 @@
 // QTNM signal generator chirp generator
+#ifndef QT_CHIRPGEN_H
+#define QT_CHIRPGEN_H
 
 // std
 
 // us
 #include "VSignal.hh"
 
-#ifndef QT_CHIRPGEN_H
-#define QT_CHIRPGEN_H
 
 class ChirpGenerator : VSignal
 {

--- a/include/signalgen/CustomNoiseGen.hh
+++ b/include/signalgen/CustomNoiseGen.hh
@@ -1,12 +1,12 @@
 // QTNM noise generator custom noise generator
+#ifndef QT_CNOISEGEN_H
+#define QT_CNOISEGEN_H
 
 // std
 
 // us
 #include "VSignal.hh"
 
-#ifndef QT_CNOISEGEN_H
-#define QT_CNOISEGEN_H
 
 class CustomNoiseGenerator : VSignal
 {

--- a/include/signalgen/SineGenerator.hh
+++ b/include/signalgen/SineGenerator.hh
@@ -1,12 +1,12 @@
 // QTNM signal generator sine generator
+#ifndef QT_SINEGEN_H
+#define QT_SINEGEN_H
 
 // std
 
 // us
 #include "VSignal.hh"
 
-#ifndef QT_SINEGEN_H
-#define QT_SINEGEN_H
 
 class SineGenerator : VSignal
 {

--- a/include/signalgen/VSignal.hh
+++ b/include/signalgen/VSignal.hh
@@ -1,10 +1,10 @@
 // QTNM signal generator abstract interface class
+#ifndef QT_VSIGNAL_H
+#define QT_VSIGNAL_H
 
 // us
 #include "types.hh"
 
-#ifndef QT_VSIGNAL_H
-#define QT_VSIGNAL_H
 
 class VSignal
 {

--- a/include/signalgen/WhiteNoiseGen.hh
+++ b/include/signalgen/WhiteNoiseGen.hh
@@ -1,12 +1,12 @@
 // QTNM noise generator white noise generator
+#ifndef QT_WNOISEGEN_H
+#define QT_WNOISEGEN_H
 
 // std
 
 // us
 #include "VSignal.hh"
 
-#ifndef QT_WNOISEGEN_H
-#define QT_WNOISEGEN_H
 
 class WhiteNoiseGenerator : VSignal
 {

--- a/include/trackMerger.hh
+++ b/include/trackMerger.hh
@@ -4,6 +4,7 @@
 
 // std includes
 #include <string>
+#include <vector>
 
 // ROOT
 #include "TTreeReader.h"
@@ -25,14 +26,18 @@ public:
   
   DataPack Loop(); // process file row by row, construct merged data pack
   // if required, otherwise pass incoming data pack through. Writer receives pack.
+
+  DataPack readRow(); // read row in file, construct data pack
+  vec_t add(vec_t& sig, double mergetime, vec_t& other); // operation no units in file IO
+  inline void clearLocal() {localWfm.clear();}
   
 private:
-  DataPack read(); // read row in file, construct data pack
-  vec_t add(vec_t& sig, double mergetime, vec_t& other); // operation no units in file IO
-
-  DataPack intermediate; // hold one pack
+  // local copies for potential merger
   int nant; // configure at construction
   int prevID;
+  int prevTrackID;
+  double localStart;
+  vec_t<vec_t> localWfm;
   
   // ROOT file access for member functions
   TTreeReader& reader;

--- a/include/trackMerger.hh
+++ b/include/trackMerger.hh
@@ -32,7 +32,7 @@ public:
 private:
   // member functions
   DataPack readRow(); // read row in file, construct data pack
-  void writeRow(DataPack dp); // write row in file from Datapack
+  void writeRow(DataPack& dp); // write row in file from Datapack
   void add(vec_t& other, int whichAntenna); // operation no units in file IO
 
   // local copies for potential merger

--- a/include/trackMerger.hh
+++ b/include/trackMerger.hh
@@ -34,7 +34,6 @@ private:
   DataPack readRow(); // read row in file, construct data pack
   void writeRow(DataPack dp); // write row in file from Datapack
   void add(vec_t& other, int whichAntenna); // operation no units in file IO
-  inline void clearLocal() {localWfm.clear();}
 
   // local copies for potential merger
   int nant; // configure at construction
@@ -42,7 +41,7 @@ private:
   int prevTrackID;
   double localStart;
   double localSampling;
-  vec_t<vec_t> localWfm;
+  std::vector<vec_t> localWfm;
   
   // ROOT file read access for member functions
   TTreeReader& reader;

--- a/include/trackMerger.hh
+++ b/include/trackMerger.hh
@@ -7,6 +7,7 @@
 #include <vector>
 
 // ROOT
+#include "TTree.h"
 #include "TTreeReader.h"
 #include "TTreeReaderValue.h"
 #include "TTreeReaderArray.h"
@@ -21,17 +22,20 @@ class trackMerger
   // hence read in here. Writing with the writeWfmToRoot module can work.
   
 public:
-  trackMerger(TTreeReader& re, int na);
+  trackMerger(TTreeReader& re, TTree* output, int na);
   virtual ~trackMerger() = default;
   
-  DataPack Loop(); // process file row by row, construct merged data pack
+  void Loop(); // process file row by row, construct merged data pack
   // if required, otherwise pass incoming data pack through. Writer receives pack.
 
-  DataPack readRow(); // read row in file, construct data pack
-  vec_t add(vec_t& sig, double mergetime, vec_t& other); // operation no units in file IO
-  inline void clearLocal() {localWfm.clear();}
   
 private:
+  // member functions
+  DataPack readRow(); // read row in file, construct data pack
+  void writeRow(DataPack dp); // write row in file from Datapack
+  void add(vec_t& other); // operation no units in file IO
+  inline void clearLocal() {localWfm.clear();}
+
   // local copies for potential merger
   int nant; // configure at construction
   int prevID;
@@ -39,9 +43,8 @@ private:
   double localStart;
   vec_t<vec_t> localWfm;
   
-  // ROOT file access for member functions
+  // ROOT file read access for member functions
   TTreeReader& reader;
-  
   TTreeReaderValue<int> nantenna;
   TTreeReaderValue<int> eventID;
   TTreeReaderValue<int> trackID;
@@ -68,6 +71,34 @@ private:
   TTreeReaderValue<std::vector<double>> hitz;
   // waveform data
   std::vector<TTreeReaderArray<double>> wfmarray;
+
+  // ROOT file write access
+  TTree* mytree;
+  std::vector<vec_t*> purewave; // no unit storage in ROOT file
+  // doubles/int for values without unit
+  int evID, trID;
+  double samplingtimeOut; // from quantity<ns>
+  double starttimeOut; // from quantity<ns>
+  double avomegaOut; // quantity<Hz>
+  double beatfOut; // quantity<Hz>
+  double chirprateOut; // quantity<Hz/s>
+  double bfieldOut; // quantity<T>
+  // vertex
+  double posxOut; // quantity<m>
+  double posyOut; // quantity<m>
+  double poszOut; // quantity<m>
+  double kEnergyOut; // quantity<eV>
+  double pangleOut; // quantity<deg>
+  std::vector<int>* trackHistory;
+  // hit data
+  std::vector<int>* hitevIDOut;
+  std::vector<int>* hittrIDOut;
+  std::vector<double>* hitxOut;
+  std::vector<double>* hityOut;
+  std::vector<double>* hitzOut;
+  std::vector<double>* hitedepOut;
+  std::vector<double>* hittimeOut;
+  std::vector<double>* hitpostthetaOut;
 };
 
 #endif

--- a/include/trackMerger.hh
+++ b/include/trackMerger.hh
@@ -33,7 +33,7 @@ private:
   // member functions
   DataPack readRow(); // read row in file, construct data pack
   void writeRow(DataPack dp); // write row in file from Datapack
-  void add(vec_t& other); // operation no units in file IO
+  void add(vec_t& other, int whichAntenna); // operation no units in file IO
   inline void clearLocal() {localWfm.clear();}
 
   // local copies for potential merger

--- a/include/trackMerger.hh
+++ b/include/trackMerger.hh
@@ -1,0 +1,68 @@
+// merge track waveforms for a given event
+#ifndef QT_MTR_H
+#define QT_MTR_H
+
+// std includes
+#include <string>
+
+// ROOT
+#include "TTreeReader.h"
+#include "TTreeReaderValue.h"
+#include "TTreeReaderArray.h"
+
+// us
+#include "Event.hh"
+
+class trackMerger
+{
+  // trackMerger class
+  // can't use WfmReader module: too specific for pipeline use
+  // hence read in here. Writing with the writeWfmToRoot module can work.
+  
+public:
+  trackMerger(TTreeReader& re, int na);
+  virtual ~trackMerger() = default;
+  
+  DataPack Loop(); // process file row by row, construct merged data pack
+  // if required, otherwise pass incoming data pack through. Writer receives pack.
+  
+private:
+  DataPack read(); // read row in file, construct data pack
+  vec_t add(vec_t& sig, double mergetime, vec_t& other); // operation no units in file IO
+
+  DataPack intermediate; // hold one pack
+  int nant; // configure at construction
+  int prevID;
+  
+  // ROOT file access for member functions
+  TTreeReader& reader;
+  
+  TTreeReaderValue<int> nantenna;
+  TTreeReaderValue<int> eventID;
+  TTreeReaderValue<int> trackID;
+  TTreeReaderValue<double> samplingtime;
+  TTreeReaderValue<double> starttime;
+  TTreeReaderValue<double> avomega;
+  TTreeReaderValue<double> beatf;
+  TTreeReaderValue<double> chirprate;
+  TTreeReaderValue<double> bfield;
+  // vertex
+  TTreeReaderValue<double> posx;
+  TTreeReaderValue<double> posy;
+  TTreeReaderValue<double> posz;
+  TTreeReaderValue<double> kEnergy;
+  TTreeReaderValue<double> pangle;
+  // hit data
+  TTreeReaderValue<std::vector<int>> hitevID;
+  TTreeReaderValue<std::vector<int>> hittrID;
+  TTreeReaderValue<std::vector<double>> hitedep; // interaction data
+  TTreeReaderValue<std::vector<double>> hittime;
+  TTreeReaderValue<std::vector<double>> hitposttheta;
+  TTreeReaderValue<std::vector<double>> hitx; // interaction location
+  TTreeReaderValue<std::vector<double>> hity;
+  TTreeReaderValue<std::vector<double>> hitz;
+  // waveform data
+  std::vector<TTreeReaderArray<double>> wfmarray;
+};
+
+#endif

--- a/include/trackMerger.hh
+++ b/include/trackMerger.hh
@@ -41,6 +41,7 @@ private:
   int prevID;
   int prevTrackID;
   double localStart;
+  double localSampling;
   vec_t<vec_t> localWfm;
   
   // ROOT file read access for member functions

--- a/modules/AddNoise.cpp
+++ b/modules/AddNoise.cpp
@@ -40,7 +40,7 @@ DataPack AddNoise::operator()(DataPack dp)
         int onset = static_cast<int>(onset_percent/100.0 * (sample_length/stime).numerical_value_in(one));
         
         for (int i=0;i<nantenna;++i) {
-          std::string ikey = "sampled_" + std::to_string(i) + "_[V]";
+          std::string ikey = "sampled_" + std::to_string(i) + "_V";
           auto pure = std::any_cast<vec_t>(indata[ikey]);
           std::cout << "retrieve key " << ikey << " waveform of size " << pure.size() << std::endl;
 

--- a/modules/FakeG4AntWriter.cpp
+++ b/modules/FakeG4AntWriter.cpp
@@ -50,12 +50,15 @@ void FakeG4AntToRoot::operator()(DataPack dp)
 
   // have generator to fill these 3 vectors
   Event<std::any> indata = dp.getRef()[inkey];
-  antennaID   = std::any_cast<std::vector<int>*>(indata["AntennaID"]); // construct first
+  std::vector<int> daID = std::any_cast<std::vector<int>>(indata["AntennaID"]); // vec<int>
+  antennaID   = &daID; // vec<int>* copy
   std::cout << " casting test: size=" << antennaID->size() << std::endl;
   mytree->SetBranchAddress("AntennaID",&antennaID);
-  timevec     = std::any_cast<vec_t*>(indata["TimeVec"]); // construct first
+  vec_t dtvec = std::any_cast<vec_t>(indata["TimeVec"]); // vec_t
+  timevec     = &dtvec; // vec_t* copy
   mytree->SetBranchAddress("TimeVec",&timevec);
-  voltagevec  = std::any_cast<vec_t*>(indata["VoltageVec"]); // construct first
+  vec_t dvvec = std::any_cast<vec_t>(indata["VoltageVec"]); // vec_t
+  voltagevec  = &dvvec; // vec_t* copy
   mytree->SetBranchAddress("VoltageVec",&voltagevec);
   mytree->SetBranchAddress("OmVec",&OMdummy); // empty
   mytree->SetBranchAddress("KEVec",&KEdummy);

--- a/modules/FakeG4AntWriter.cpp
+++ b/modules/FakeG4AntWriter.cpp
@@ -1,0 +1,65 @@
+// Root Fake Geant4 Antenna Sim Writer module implementation
+
+// std
+#include <iostream>
+
+// us
+#include "FakeG4AntWriter.hh"
+
+
+FakeG4AntToRoot::FakeG4AntToRoot(std::string inkey, TTree* tr) : 
+  inkey(std::move(inkey)),
+  mytree(tr)
+{
+  // can now point branch at dummy addresses; makes header only
+  mytree->Branch("EventID",&evID,"EventID/I");
+  mytree->Branch("TrackID",&trID,"TrackID/I");
+  mytree->Branch("Posx",&dx,"Posx/D");
+  mytree->Branch("Posy",&dy,"Posy/D");
+  mytree->Branch("Posz",&dz,"Posz/D");
+  mytree->Branch("KinEnergy",&dke,"KinEnergy/D");
+  mytree->Branch("PitchAngle",&dang,"PitchAngle/D");
+
+  mytree->Branch("AntennaID", &antennaID); // point to vec_t dummy address
+  mytree->Branch("TimeVec", &timevec); // point to vec_t dummy address
+  mytree->Branch("VoltageVec", &voltagevec); // point to vec_t dummy address
+  mytree->Branch("OmVec", &KEdummy); // point to vec_t dummy address
+  mytree->Branch("KEVec", &OMdummy); // point to vec_t dummy address
+  }
+
+}
+
+
+void FakeG4AntToRoot::operator()(DataPack dp)
+{
+  // extract from datapack and assign to output branch variables with the correct address
+  // have generator to fill eventID and trackID
+  evID = dp.getTruthRef().vertex.eventID;
+  mytree->SetBranchAddress("EventID",&evID);
+  trID = dp.getTruthRef().vertex.trackID;
+  mytree->SetBranchAddress("TrackID",&trID);
+  dx    = 0.0; // empty
+  mytree->SetBranchAddress("Posx",&dx);
+  dy    = 0.0;
+  mytree->SetBranchAddress("Posy",&dy);
+  dz    = 0.0;
+  mytree->SetBranchAddress("Posz",&dz);
+  dke   = 0.0;
+  mytree->SetBranchAddress("KinEnergy",&dke);
+  dang  = 0.0;
+  mytree->SetBranchAddress("PitchAngle",&dang);
+
+  // have generator to fill these 3 vectors
+  Event<std::any> indata = dp.getRef()[inkey];
+  antennaID   = std::any_cast<std::vector<int>>(indata["AntennaID"]); // construct first
+  mytree->SetBranchAddress("AntennaID",&antennaID);
+  timevec     = std::any_cast<vec_t>(indata["TimeVec"]); // construct first
+  mytree->SetBranchAddress("TimeVec",&timevec);
+  voltagevec  = std::any_cast<vec_t>(indata["VoltageVec"]); // construct first
+  mytree->SetBranchAddress("VoltageVec",&voltagevec);
+  mytree->SetBranchAddress("OmVec",&OMdummy); // empty
+  mytree->SetBranchAddress("KEVec",&KEdummy);
+
+  // all output collected, write it
+  mytree->Fill();
+}

--- a/modules/FakeG4AntWriter.cpp
+++ b/modules/FakeG4AntWriter.cpp
@@ -25,7 +25,6 @@ FakeG4AntToRoot::FakeG4AntToRoot(std::string inkey, TTree* tr) :
   mytree->Branch("VoltageVec", &voltagevec); // point to vec_t dummy address
   mytree->Branch("OmVec", &KEdummy); // point to vec_t dummy address
   mytree->Branch("KEVec", &OMdummy); // point to vec_t dummy address
-  }
 
 }
 

--- a/modules/FakeG4AntWriter.cpp
+++ b/modules/FakeG4AntWriter.cpp
@@ -50,11 +50,12 @@ void FakeG4AntToRoot::operator()(DataPack dp)
 
   // have generator to fill these 3 vectors
   Event<std::any> indata = dp.getRef()[inkey];
-  antennaID   = std::any_cast<std::vector<int>>(indata["AntennaID"]); // construct first
+  antennaID   = std::any_cast<std::vector<int>*>(indata["AntennaID"]); // construct first
+  std::cout << " casting test: size=" << antennaID->size() << std::endl;
   mytree->SetBranchAddress("AntennaID",&antennaID);
-  timevec     = std::any_cast<vec_t>(indata["TimeVec"]); // construct first
+  timevec     = std::any_cast<vec_t*>(indata["TimeVec"]); // construct first
   mytree->SetBranchAddress("TimeVec",&timevec);
-  voltagevec  = std::any_cast<vec_t>(indata["VoltageVec"]); // construct first
+  voltagevec  = std::any_cast<vec_t*>(indata["VoltageVec"]); // construct first
   mytree->SetBranchAddress("VoltageVec",&voltagevec);
   mytree->SetBranchAddress("OmVec",&OMdummy); // empty
   mytree->SetBranchAddress("KEVec",&KEdummy);

--- a/modules/FullAntennaSimReader.cpp
+++ b/modules/FullAntennaSimReader.cpp
@@ -111,7 +111,10 @@ DataPack FullAntennaSimReader::operator()()
         }
         reader2.Restart(); // for each trajectory, have to loop over hits, then reset hits reader.
     }
-
+    if (!tvec->empty()) // book truth from trajectory
+      dp.getTruthRef().start_time = tvec->front() * ns;
+    else
+      dp.getTruthRef().start_time = -1.0 * ns;
     dp.getTruthRef().bfield = Bfield; // store input truth
     return dp;
 }

--- a/modules/FullKinematicsSimReader.cpp
+++ b/modules/FullKinematicsSimReader.cpp
@@ -122,7 +122,10 @@ DataPack FullKinematicsSimReader::operator()()
         }
         reader2.Restart(); // for each trajectory, have to loop over hits, then reset hits reader.
     }
-
+    if (!tvec->empty()) // book truth from trajectory
+      dp.getTruthRef().start_time = tvec->front() * ns;
+    else
+      dp.getTruthRef().start_time = -1.0 * ns;
     dp.getTruthRef().bfield = Bfield; // store input truth
     return dp;
 }

--- a/modules/OmegaBeatToTruth.cpp
+++ b/modules/OmegaBeatToTruth.cpp
@@ -11,7 +11,7 @@
 
 OmegaBeatToTruth::OmegaBeatToTruth(std::string in, std::string out) : 
   inkey(std::move(in)),
-  outkey(std::move(out))
+  outkey(std::move(out)) // not used beyond testing
 {}
 
 DataPack OmegaBeatToTruth::operator()(DataPack dp)
@@ -41,15 +41,14 @@ DataPack OmegaBeatToTruth::operator()(DataPack dp)
         auto idx = std::distance(res.begin(), loc); // index of max
 	std::cout << "loc from distance; " << idx << std::endl;
         std::cout << "frequency peak at " << freq.at(idx) << std::endl; // use index on freq vector
-        dp.getTruthRef().beat_frequency = freq.at(idx);
-	// store output
-	outdata["omfft"] = std::any_cast<waveform_t>(res);   // q<V>, again cheated unit for use of dft()
-	outdata["omfreq"] = std::any_cast<std::vector<quantity<Hz>>>(freq); // q<Hz>
+        dp.getTruthRef().beat_frequency = freq.at(idx); // truth output
+	// outdata["omfft"] = std::any_cast<waveform_t>(res);   // q<V>, again cheated unit for use of dft()
+	// outdata["omfreq"] = std::any_cast<std::vector<quantity<Hz>>>(freq); // q<Hz>
     }
     catch(const std::bad_any_cast& e)
     {
       std::cerr << "OmegaBeatToTruth: " << e.what() << '\n';
     }
-    dp.getRef()[outkey] = outdata;
+    //    dp.getRef()[outkey] = outdata; // not used beyond testing
     return dp;
 }

--- a/modules/OmegaBeatToTruth.cpp
+++ b/modules/OmegaBeatToTruth.cpp
@@ -32,7 +32,7 @@ DataPack OmegaBeatToTruth::operator()(DataPack dp)
     try
     {
         // get hold of truth data from sim
-        auto omvec = std::any_cast<std::vector<double>>(indata["omega"]); // sampled in wfmsampling
+        auto omvec = std::any_cast<vec_t>(indata["omega"]); // sampled in wfmsampling
         // convert to waveform_t with unit, cheat to enable use of dft()
         waveform_t res;
         for (auto entry : omvec) res.push_back(entry/1.e9/(2.0*myPi) * V); // omega/2pi as double->quantity<V>

--- a/modules/QTNMSimAntennaReader.cpp
+++ b/modules/QTNMSimAntennaReader.cpp
@@ -77,6 +77,10 @@ DataPack QTNMSimAntennaReader::operator()()
     dp.getTruthRef().vertex.pitchangle = *pangle * rad;
     std::cout << "reader Next() done, evt:  " << evcounter << std::endl;
 
+    if (!tvec->empty()) // book truth from trajectory
+      dp.getTruthRef().start_time = tvec->front() * ns;
+    else
+      dp.getTruthRef().start_time = -1.0 * ns;
     dp.getTruthRef().bfield = Bfield; // store input truth
     return dp;
 }

--- a/modules/QTNMSimKinematicsReader.cpp
+++ b/modules/QTNMSimKinematicsReader.cpp
@@ -88,6 +88,10 @@ DataPack QTNMSimKinematicsReader::operator()()
     dp.getTruthRef().vertex.pitchangle = *pangle * rad;
     std::cout << "reader Next() done, evt:  " << evcounter << std::endl;
 
+    if (!tvec->empty()) // book truth from trajectory
+      dp.getTruthRef().start_time = tvec->front() * ns;
+    else
+      dp.getTruthRef().start_time = -1.0 * ns;
     dp.getTruthRef().bfield = Bfield; // store input truth
     return dp;
 }

--- a/modules/SineSigGenerator.cpp
+++ b/modules/SineSigGenerator.cpp
@@ -11,7 +11,8 @@
 SineSigGenerator::SineSigGenerator(std::string out) : 
     outkey(std::move(out)),
     counter(0),
-    maxEventNumber(0)
+    maxEventNumber(0),
+    frequency(0.0*Hz) // signal incomplete config
     {}
 
 SineSigGenerator::SineSigGenerator(std::string out, quantity<V> amp, quantity<Hz> freq, quantity<Hz> srate, 
@@ -35,22 +36,26 @@ SineSigGenerator::SineSigGenerator(std::string out, quantity<V> amp, quantity<Hz
 
 DataPack SineSigGenerator::operator()()
 {
-    if (counter > maxEventNumber)
-        throw yap::GeneratorExit{};
-    counter++;
-
-    Event_map<std::any> eventmap; // data item for delivery
-    Event<std::any> outdata; // to hold all the data items
-
-    outdata["waveform_V_0"] = std::make_any<waveform_t>(sig.generate()); // use generator
-    outdata["amplitude_V_0"] = std::make_any<quantity<V>>(amplitude);
-    outdata["frequency_Hz_0"] = std::make_any<quantity<Hz>>(frequency);
-    outdata["sampling_Hz_0"] = std::make_any<quantity<Hz>>(sampling_rate);
-    outdata["duration_s_0"] = std::make_any<quantity<s>>(duration);
-    outdata["phase_rad_0"] = std::make_any<quantity<rad>>(phase);
-    std::cout << "sine gen: counter " << counter << ", in key " << outkey << std::endl;
-    eventmap[outkey] = outdata;
-    DataPack dp(eventmap);
-    dp.getTruthRef().nantenna = 1; // required for outputs
-    return dp;
+  if (frequency<=0.0*Hz) {
+    std::cout << "Error, SineSigGenerator: incomplete configuration." << std::endl;
+    throw yap::GeneratorExit{};
+  }
+  if (counter > maxEventNumber)
+    throw yap::GeneratorExit{};
+  counter++;
+  
+  Event_map<std::any> eventmap; // data item for delivery
+  Event<std::any> outdata; // to hold all the data items
+  
+  outdata["waveform_V_0"] = std::make_any<waveform_t>(sig.generate()); // use generator
+  outdata["amplitude_V_0"] = std::make_any<quantity<V>>(amplitude);
+  outdata["frequency_Hz_0"] = std::make_any<quantity<Hz>>(frequency);
+  outdata["sampling_Hz_0"] = std::make_any<quantity<Hz>>(sampling_rate);
+  outdata["duration_s_0"] = std::make_any<quantity<s>>(duration);
+  outdata["phase_rad_0"] = std::make_any<quantity<rad>>(phase);
+  std::cout << "sine gen: counter " << counter << ", in key " << outkey << std::endl;
+  eventmap[outkey] = outdata;
+  DataPack dp(eventmap);
+  dp.getTruthRef().nantenna = 1; // required for outputs
+  return dp;
 }

--- a/modules/TestG4AntGenerator.cpp
+++ b/modules/TestG4AntGenerator.cpp
@@ -1,0 +1,87 @@
+// Test Geant4 Antenna signal generator module implementation
+
+// std
+#include <iostream>
+
+// us
+#include "TestG4AntGenerator.hh"
+#include "yap/pipeline.h"
+
+
+TestG4AntGenerator::TestG4AntGenerator(std::string out) : 
+  outkey(std::move(out)),
+  counter(0),
+  maxEventNumber(4), // make 4 different signals for test
+  nantenna(1),
+  frequency(0.0*Hz),
+  amplitude(-1.0*V), // signal incomplete config
+  sampling_rate(0.0*Hz),
+  duration(0.0*s),
+  phase(0.0*rad)
+{}
+
+
+DataPack TestG4AntGenerator::operator()()
+{
+  if (amplitude<=0.0*V) {
+    std::cout << "Error, TestG4AntGenerator: incomplete configuration." << std::endl;
+    throw yap::GeneratorExit{};
+  }
+  if (counter >= maxEventNumber)
+    throw yap::GeneratorExit{};
+  counter++;
+
+  // configure generator
+  // first signal
+  sig.setAmplitude(amplitude);
+  sig.setFrequency(frequency);
+  sig.setSampling_rate(sampling_rate);
+  sig.setDuration(duration);
+  sig.setPhase_rad(phase);
+  vec_t basesig = sig.generate_pattern(); // waveform 1
+
+  // second signal
+  sig.setFrequency(frequency + 1.0*GHz); // shift by 1GHz
+  sig.setDuration(duration/2.0); // half long
+  vec_t track2 = sig.generate_pattern(); // waveform 2
+  
+  // make signal number 'counter', 4 test cases
+  int eID, tID;
+  switch(counter) {
+  case 1:
+    std::vector<int> aID;
+    vec_t vvec, tvec;
+    for (int j;j<basesig.size();j++) {
+      for (int i=0;i<nantenna;++i) {
+	aID.push_back(i);
+	vvec.push_back(basesig.at(j));
+	tvec.push_back(j/sampling_rate); // unit, check
+      }
+    }
+    eID = 1;
+    tID = 1; // just single waveform
+  case 2:
+
+  case 3:
+
+  case 4:
+    
+  }
+  
+  // prepare fake Geant4 output data
+  Event_map<std::any> eventmap; // data item for delivery
+  Event<std::any> outdata; // to hold all the data items
+  
+  outdata["AntennaID"] = std::make_any<vec_t>(); // interleaved as in G4
+  outdata["VoltageVec"] = std::make_any<vec_t>();
+  outdata["TimeVec"] = std::make_any<vec_t>();
+
+  std::cout << "sine gen: counter " << counter << ", in key " << outkey << std::endl;
+  eventmap[outkey] = outdata;
+  DataPack dp(eventmap);
+  dp.getTruthRef().vertex.eventID = eID; // required for outputs
+  dp.getTruthRef().vertex.trackID = tID; // required for outputs
+  dp.getTruthRef().nantenna = nantenna; // required for outputs
+
+  return dp;
+}

--- a/modules/TestG4AntGenerator.cpp
+++ b/modules/TestG4AntGenerator.cpp
@@ -43,6 +43,7 @@ DataPack TestG4AntGenerator::operator()()
   vec_t basesig = sig.generate_pattern(); // waveform 1
 
   // second signal
+  sig.setAmplitude(amplitude/2.0); // smaller signal
   sig.setFrequency(frequency + 1.0*GHz); // shift by 1GHz, low energy generic f shift
   sig.setDuration(duration/2.0); // half length
   vec_t track2 = sig.generate_pattern(); // waveform 2
@@ -65,7 +66,7 @@ DataPack TestG4AntGenerator::operator()()
       for (int i=0;i<nantenna;++i) { // interleaving like in G4 output
 	aID.push_back(i);
 	vvec.push_back(basesig.at(j));
-	tvec.push_back(j * samplinginterval); // [ns]
+	tvec.push_back(j * sampleinterval); // [ns]
       }
     }
     outdata["AntennaID"] = std::make_any<std::vector<int>>(aID);
@@ -91,7 +92,7 @@ DataPack TestG4AntGenerator::operator()()
       for (int i=0;i<nantenna;++i) {
 	aID.push_back(i);
 	vvec.push_back(track2.at(j));
-	tvec.push_back(timeshift*samplinginterval + j * samplinginterval); // [ns]
+	tvec.push_back(timeshift*sampleinterval + j * sampleinterval); // [ns]
       } // offset tvec by timeshift
     }
     outdata["AntennaID"] = std::make_any<std::vector<int>>(aID);

--- a/modules/WaveformSampling.cpp
+++ b/modules/WaveformSampling.cpp
@@ -55,7 +55,7 @@ DataPack WaveformSampling::operator()(DataPack dp)
 	  vec_t resampled = interpolate(tt, tv);
 	  tv.clear();
 	  std::cout << "interpolator signal done, antenna " << i << std::endl;
-	  std::string tkey = "sampled_" + std::to_string(i) + "_[V]";
+	  std::string tkey = "sampled_" + std::to_string(i) + "_V";
 	  outdata[tkey] = std::make_any<vec_t>(resampled);
 	}
 	vec_t omresampled = interpolate(tt, omvec);
@@ -96,7 +96,7 @@ DataPack WaveformSampling::operator()(DataPack dp)
               << " time vec size " << tiv.size()<< std::endl;
 	  vec_t resampled = interpolate(tiv, tv);
 	  // store result
-	  std::string okey = "sampled_" + std::to_string(i) + "_[V]";
+	  std::string okey = "sampled_" + std::to_string(i) + "_V";
 	  outdata[okey] = std::make_any<vec_t>(resampled); // for later transformation and deletion
 	  dp.getRef()[inkey].erase(ikey); // used; not needed anymore
 	}

--- a/modules/WaveformSampling.cpp
+++ b/modules/WaveformSampling.cpp
@@ -46,21 +46,18 @@ DataPack WaveformSampling::operator()(DataPack dp)
 	ROOT::VecOps::RVec<double> tempt(tiv); // temporary
 	ROOT::VecOps::RVec<double> tempv(vvv); // temporary
 	
+	auto selecttvec = tempt[tempant==0]; // like NumPy selection
+	vec_t tt(selecttvec.begin(),selecttvec.end()); // sample_time same for any antenna
 	for (int i=0;i<nantenna;++i) {
-	  auto selecttvec = tempt[tempant==i]; // like NumPy selection
 	  auto selectvvec = tempv[tempant==i];
-	  vec_t tt(selecttvec.begin(),selecttvec.end()); // copy from RVec
 	  vec_t tv(selectvvec.begin(),selectvvec.end());
 	  
 	  vec_t resampled = interpolate(tt, tv);
-	  tt.clear();
 	  tv.clear();
 	  std::cout << "interpolator signal done, antenna " << i << std::endl;
 	  std::string tkey = "sampled_" + std::to_string(i) + "_[V]";
 	  outdata[tkey] = std::make_any<vec_t>(resampled);
 	}
-	auto selecttvec = tempt[tempant==0]; // like NumPy selection
-	vec_t tt(selecttvec.begin(),selecttvec.end()); // sample_time same for any antenna
 	vec_t omresampled = interpolate(tt, omvec);
 	outdata["omega"] = std::make_any<vec_t>(omresampled); // for the beat freq
 	dp.getTruthRef().average_omega = average_omega(omvec);

--- a/modules/WfmReader.cpp
+++ b/modules/WfmReader.cpp
@@ -2,6 +2,7 @@
 
 // std
 #include <iostream>
+#include <string>
 
 // us
 #include "WfmReader.hh"
@@ -10,58 +11,52 @@
 // ROOT
 #include "TTreeReaderValue.h"
 
-WfmReader::WfmReader(TTreeReader& re, std::string out) : 
+WfmReader::WfmReader(TTreeReader& re, int nant, std::string out) : 
     outkey(std::move(out)),
     reader(re1),
-    eventID(reader, "EventID"), // needs reader by reference
-    trackID(reader, "TrackID"),
-    hitevID(reader2, "EventID"), // interaction data
-    hittrID(reader2, "TrackID"),
-    edep(reader2, "Edep"), 
-    tstamp(reader2, "TimeStamp"),
-    prek(reader2, "PreKine"),
-    postk(reader2, "PostKine"),
-    preth(reader2, "PreTheta"),
-    postth(reader2, "PostTheta"),
-    locx(reader2, "Posx"), // interaction location
-    locy(reader2, "Posy"),
-    locz(reader2, "Posz"),
-    posx(reader, "Posx"), // vertex data
-    posy(reader, "Posy"),
-    posz(reader, "Posz"),
-    kine(reader, "KinEnergy"),
-    pangle(reader, "PitchAngle"),
-    wfmvec(reader, "VoltageVec")
+    eventID(reader, "vertex_evID"), // needs reader by reference
+    trackID(reader, "vertex_trackID"),
+    hitevID(reader, "hit_eventID"), // interaction data
+    hittrID(reader, "hit_trackID"),
+    hitedep(reader, "hit_edep_eV"), 
+    hittime(reader, "hit_time_ns"),
+    hitposttheta(reader, "hit_posttheta_deg"),
+    hitx(reader, "hit_locx_m"), // interaction location
+    hity(reader, "hit_locy_m"),
+    hitz(reader, "hit_locz_m"),
+    posx(reader, "vertex_posx_m"), // vertex data
+    posy(reader, "vertex_posy_m"),
+    posz(reader, "vertex_posz_m"),
+    kEnergye(reader, "vertex_kinenergy_eV"),
+    pangle(reader, "vertex_pitchangle_deg"),
+    samplingtime(reader, "truth_samplingtime_s"),
+    avomega(reader, "truth_avomega_Hz"),
+    beatf(reader, "truth_beatf_Hz"),
+    chirprate(reader, "truth_chirp_Hz_s"),
+    bfield(reader, "truth_bfield_T"),
+    nantenna(reader, "truth_nantenna")
 {
-    std::cout << "in reader n entries: " << reader.GetEntries() << std::endl;
+  // int nant for n antenna is needed at construction time
+  std::string brname;
+  for (int i=0;i<nant;++i) {
+    brname = "sampled_" + std::to_string(i) + "_[V]";
+    wfmvec.push_back(wfm(reader, brname.data()));
+  }
+  std::cout << "in reader n entries: " << reader.GetEntries() << std::endl;
 }
 
 DataPack WfmReader::operator()()
 {
-    // catch event number limit in pipeline, -1 = all, default
-    if ((evcounter > maxEventNumber &&   // reached maximum event number
-        maxEventNumber > 0) ||          // max has been set
-        evcounter >= reader1.GetEntries()) // reached end of file
-    
-        throw yap::GeneratorExit{};
-    evcounter++;
-
-    if (Bfield < 0 * T) {
-        std::cout << "WARNING: Bfield is required input to pipeline. Exit" << std::endl;
-        throw yap::GeneratorExit{};
-    }
-
     Event_map<std::any> eventmap; // data item for delivery
     Event<std::any> outdata; // to hold all the data items from file
 
     // collect all trajectory info from file, reader holds event iterator
     // std::cout << "reader called" << std::endl;
-    if (reader1.Next()) { // variables filled from file
-        outdata["AntennaID"] = std::make_any<std::vector<int>>(aID->begin(),aID->end());
-        outdata["TimeVec"] = std::make_any<std::vector<double>>(tvec->begin(),tvec->end());
-        outdata["VoltageVec"] = std::make_any<std::vector<double>>(vvec->begin(),vvec->end());
-        outdata["OmVec"] = std::make_any<std::vector<double>>(omvec->begin(),omvec->end());
-        outdata["KEVec"] = std::make_any<std::vector<double>>(kevec->begin(),kevec->end());
+    std:string brname;
+    if (reader.Next()) { // variables filled from file
+      for (int i=0;i<nantenna;++i) {
+	brname = "sampled_" + std::to_string(i) + "_[V]";
+        outdata[brname.data()] = std::make_any<vec_t>(wfmvec.at(i)->begin(), wfmvec.at(i)->end());
         eventmap[outkey] = outdata; // with outdata an Event<std::any>
     }
     else // no more entries in TTreeReader
@@ -76,34 +71,30 @@ DataPack WfmReader::operator()()
     dp.getTruthRef().vertex.posx = *posx * mm;
     dp.getTruthRef().vertex.posy = *posy * mm;
     dp.getTruthRef().vertex.posz = *posz * mm;
-    dp.getTruthRef().vertex.kineticenergy = *kine * keV;
+    dp.getTruthRef().vertex.kineticenergy = *kEnergy * keV;
     dp.getTruthRef().vertex.pitchangle = *pangle * rad;
-    std::cout << "reader1 Next() done, evt:  " << evcounter << std::endl;
 
     // check on hits, separately from trajectory reader
     // the hit reader may or may not hold data.
-    if (reader2.GetEntries() > 0) { // if there is any hit at all, check with trajectory
-        while (reader2.Next()) { // get first entry, fill all data items
-            if (*hitevID == *eventID) { // only if this trajectory has a hit
-                dp.getHitRef().eventID   = *hitevID;
-                dp.getHitRef().trackID   = *hittrID;
-                dp.getHitRef().edeposit  = *edep * keV;
-                dp.getHitRef().timestamp = *tstamp * ns;
-                dp.getHitRef().kepre = *prek * keV;
-                dp.getHitRef().kepost = *postk * keV;
-                dp.getHitRef().anglepre = *preth * rad;
-                dp.getHitRef().anglepost = *postth * rad;
-                dp.getHitRef().locx = *locx * mm;
-                dp.getHitRef().locy = *locy * mm;
-                dp.getHitRef().locz = *locz * mm;
-                // store the filled hit_t
-                dp.hitsRef().push_back(dp.getHit());
-                std::cout << "found hit evt/track:  " << *hitevID << ", " << *hittrID << std::endl;
-            }
-        }
-        reader2.Restart(); // for each trajectory, have to loop over hits, then reset hits reader.
+    if (! hitevID->empty()) {
+      for (unsigned int j=0;j<hitevID->size();++j) {
+	dp.getHitRef().eventID   = hitevID->at(j);
+	dp.getHitRef().trackID   = hittrID->at(j);
+	dp.getHitRef().edeposit  = hitedep->at(j) * keV;
+	dp.getHitRef().timestamp = hittime->at(j) * ns;
+	dp.getHitRef().anglepost = hitposttheta->at(j) * rad;
+	dp.getHitRef().locx = hitx->at(j) * mm;
+	dp.getHitRef().locy = hity->at(j) * mm;
+	dp.getHitRef().locz = hitz->at(j) * mm;
+	// store the filled hit_t
+	dp.hitsRef().push_back(dp.getHit());
+      }
     }
-
-    dp.getTruthRef().bfield = Bfield; // store input truth
+    dp.getTruthRef().nantenna = *nantenna; // store input truth
+    dp.getTruthRef().chirp_rate = *chirprate * Hz/s; // store input truth
+    dp.getTruthRef().beat_frequency = *beatf * Hz; // store input truth
+    dp.getTruthRef().average_omega = *avomega * Hz; // store input truth
+    dp.getTruthRef().sampling_time = *sampplingtime * ns; // store input truth
+    dp.getTruthRef().bfield = *bfield * T; // store input truth
     return dp;
 }

--- a/modules/WfmReader.cpp
+++ b/modules/WfmReader.cpp
@@ -10,8 +10,9 @@
 
 WfmReader::WfmReader(TTreeReader& re, int na, std::string out) : 
     outkey(std::move(out)),
-    reader(re1),
+    reader(re),
     nant(na),
+    nantenna(reader, "truth_nantenna"),
     eventID(reader, "vertex_evID"), // needs reader by reference
     trackID(reader, "vertex_trackID"),
     hitevID(reader, "hit_eventID"), // interaction data
@@ -25,14 +26,13 @@ WfmReader::WfmReader(TTreeReader& re, int na, std::string out) :
     posx(reader, "vertex_posx_m"), // vertex data
     posy(reader, "vertex_posy_m"),
     posz(reader, "vertex_posz_m"),
-    kEnergye(reader, "vertex_kinenergy_eV"),
+    kEnergy(reader, "vertex_kinenergy_eV"),
     pangle(reader, "vertex_pitchangle_deg"),
     samplingtime(reader, "truth_samplingtime_s"),
     avomega(reader, "truth_avomega_Hz"),
     beatf(reader, "truth_beatf_Hz"),
     chirprate(reader, "truth_chirp_Hz_s"),
-    bfield(reader, "truth_bfield_T"),
-    nantenna(reader, "truth_nantenna")
+    bfield(reader, "truth_bfield_T")
 {
   // int nant for n antenna is needed at construction time
   std::string brname;
@@ -50,11 +50,12 @@ DataPack WfmReader::operator()()
 
     // collect all trajectory info from file, reader holds event iterator
     // std::cout << "reader called" << std::endl;
-    std:string brname;
+    std::string brname;
     if (reader.Next()) { // variables filled from file
       for (int i=0;i<nant;++i) {
 	brname = "sampled_" + std::to_string(i) + "_V";
-        outdata[brname] = std::make_any<vec_t>(wfm(wfmarray.at(i).begin(), wfmarray.at(i).end()));
+	vec_t wfm(wfmarray.at(i).begin(), wfmarray.at(i).end());
+        outdata[brname] = std::make_any<vec_t>(wfm);
         eventmap[outkey] = outdata; // with outdata an Event<std::any>
       }
     }
@@ -93,7 +94,7 @@ DataPack WfmReader::operator()()
     dp.getTruthRef().chirp_rate = *chirprate * Hz/s; // store input truth
     dp.getTruthRef().beat_frequency = *beatf * Hz; // store input truth
     dp.getTruthRef().average_omega = *avomega * Hz; // store input truth
-    dp.getTruthRef().sampling_time = *sampplingtime * ns; // store input truth
+    dp.getTruthRef().sampling_time = *samplingtime * ns; // store input truth
     dp.getTruthRef().bfield = *bfield * T; // store input truth
     return dp;
 }

--- a/modules/WfmReader.cpp
+++ b/modules/WfmReader.cpp
@@ -1,0 +1,109 @@
+// waveform reader module implementation
+
+// std
+#include <iostream>
+
+// us
+#include "WfmReader.hh"
+#include "yap/pipeline.h"
+
+// ROOT
+#include "TTreeReaderValue.h"
+
+WfmReader::WfmReader(TTreeReader& re, std::string out) : 
+    outkey(std::move(out)),
+    reader(re1),
+    eventID(reader, "EventID"), // needs reader by reference
+    trackID(reader, "TrackID"),
+    hitevID(reader2, "EventID"), // interaction data
+    hittrID(reader2, "TrackID"),
+    edep(reader2, "Edep"), 
+    tstamp(reader2, "TimeStamp"),
+    prek(reader2, "PreKine"),
+    postk(reader2, "PostKine"),
+    preth(reader2, "PreTheta"),
+    postth(reader2, "PostTheta"),
+    locx(reader2, "Posx"), // interaction location
+    locy(reader2, "Posy"),
+    locz(reader2, "Posz"),
+    posx(reader, "Posx"), // vertex data
+    posy(reader, "Posy"),
+    posz(reader, "Posz"),
+    kine(reader, "KinEnergy"),
+    pangle(reader, "PitchAngle"),
+    wfmvec(reader, "VoltageVec")
+{
+    std::cout << "in reader n entries: " << reader.GetEntries() << std::endl;
+}
+
+DataPack WfmReader::operator()()
+{
+    // catch event number limit in pipeline, -1 = all, default
+    if ((evcounter > maxEventNumber &&   // reached maximum event number
+        maxEventNumber > 0) ||          // max has been set
+        evcounter >= reader1.GetEntries()) // reached end of file
+    
+        throw yap::GeneratorExit{};
+    evcounter++;
+
+    if (Bfield < 0 * T) {
+        std::cout << "WARNING: Bfield is required input to pipeline. Exit" << std::endl;
+        throw yap::GeneratorExit{};
+    }
+
+    Event_map<std::any> eventmap; // data item for delivery
+    Event<std::any> outdata; // to hold all the data items from file
+
+    // collect all trajectory info from file, reader holds event iterator
+    // std::cout << "reader called" << std::endl;
+    if (reader1.Next()) { // variables filled from file
+        outdata["AntennaID"] = std::make_any<std::vector<int>>(aID->begin(),aID->end());
+        outdata["TimeVec"] = std::make_any<std::vector<double>>(tvec->begin(),tvec->end());
+        outdata["VoltageVec"] = std::make_any<std::vector<double>>(vvec->begin(),vvec->end());
+        outdata["OmVec"] = std::make_any<std::vector<double>>(omvec->begin(),omvec->end());
+        outdata["KEVec"] = std::make_any<std::vector<double>>(kevec->begin(),kevec->end());
+        eventmap[outkey] = outdata; // with outdata an Event<std::any>
+    }
+    else // no more entries in TTreeReader
+        throw yap::GeneratorExit{};
+
+    // make data product
+    // at the end, store new data product in dictionary event map.
+    DataPack dp(eventmap);
+    // fill truth struct with vertex info
+    dp.getTruthRef().vertex.eventID = *eventID;
+    dp.getTruthRef().vertex.trackID = *trackID;
+    dp.getTruthRef().vertex.posx = *posx * mm;
+    dp.getTruthRef().vertex.posy = *posy * mm;
+    dp.getTruthRef().vertex.posz = *posz * mm;
+    dp.getTruthRef().vertex.kineticenergy = *kine * keV;
+    dp.getTruthRef().vertex.pitchangle = *pangle * rad;
+    std::cout << "reader1 Next() done, evt:  " << evcounter << std::endl;
+
+    // check on hits, separately from trajectory reader
+    // the hit reader may or may not hold data.
+    if (reader2.GetEntries() > 0) { // if there is any hit at all, check with trajectory
+        while (reader2.Next()) { // get first entry, fill all data items
+            if (*hitevID == *eventID) { // only if this trajectory has a hit
+                dp.getHitRef().eventID   = *hitevID;
+                dp.getHitRef().trackID   = *hittrID;
+                dp.getHitRef().edeposit  = *edep * keV;
+                dp.getHitRef().timestamp = *tstamp * ns;
+                dp.getHitRef().kepre = *prek * keV;
+                dp.getHitRef().kepost = *postk * keV;
+                dp.getHitRef().anglepre = *preth * rad;
+                dp.getHitRef().anglepost = *postth * rad;
+                dp.getHitRef().locx = *locx * mm;
+                dp.getHitRef().locy = *locy * mm;
+                dp.getHitRef().locz = *locz * mm;
+                // store the filled hit_t
+                dp.hitsRef().push_back(dp.getHit());
+                std::cout << "found hit evt/track:  " << *hitevID << ", " << *hittrID << std::endl;
+            }
+        }
+        reader2.Restart(); // for each trajectory, have to loop over hits, then reset hits reader.
+    }
+
+    dp.getTruthRef().bfield = Bfield; // store input truth
+    return dp;
+}

--- a/modules/writeDigitizerToRoot.cpp
+++ b/modules/writeDigitizerToRoot.cpp
@@ -3,12 +3,9 @@
 
 // std
 #include <iostream>
-#include <algorithm>
-#include <memory>
 
 // us
 #include "writeDigitizerToRoot.hh"
-#include "types.hh"
 
 WriterDigiToRoot::WriterDigiToRoot(TTree* tr, int na) : 
   mytree(tr),

--- a/modules/writeDigitizerToRoot.cpp
+++ b/modules/writeDigitizerToRoot.cpp
@@ -23,6 +23,7 @@ WriterDigiToRoot::WriterDigiToRoot(TTree* tr, int na) :
   mytree->Branch("truth_nantenna",&nant,"truth_nantenna/I");
   mytree->Branch("truth_snratio",&snratio,"truth_snratio/D");
   mytree->Branch("truth_samplingtime_s",&samplingtime,"truth_samplingtime/D");
+  mytree->Branch("truth_starttime_s",&starttime,"truth_starttime/D");
   mytree->Branch("truth_avomega_Hz",&avomega,"truth_avomega/D");
   mytree->Branch("truth_beatf_Hz",&beatf,"truth_beatf/D");
   mytree->Branch("truth_chirp_Hz_s",&chirprate,"truth_chirp_rate/D");
@@ -33,6 +34,7 @@ WriterDigiToRoot::WriterDigiToRoot(TTree* tr, int na) :
   mytree->Branch("vertex_posz_m",&posz,"vertex_posz/D");
   mytree->Branch("vertex_kinenergy_eV",&kEnergy,"vertex_kinenergy/D");
   mytree->Branch("vertex_pitchangle_deg",&pangle,"vertex_pitchangle/D");
+  mytree->Branch("vertex_trackHistory",&trackHistory);
   mytree->Branch("digi_gain",&gain,"digi_gain/D");
   mytree->Branch("digi_tfrequency_Hz",&tfrequency,"digi_tfrequency/D");
   mytree->Branch("digi_samplingrate_Hz",&digisamplingrate,"digi_samplingrate/D");
@@ -56,6 +58,8 @@ void WriterDigiToRoot::operator()(DataPack dp)
   mytree->SetBranchAddress("truth_snratio",&snratio);
   samplingtime = dp.getTruthRef().sampling_time.numerical_value_in(s); // from quantity<ns> no unit for output
   mytree->SetBranchAddress("truth_samplingtime_s",&samplingtime);
+  starttime = dp.getTruthRef().start_time.numerical_value_in(s); // from quantity<ns> no unit for output
+  mytree->SetBranchAddress("truth_starttime_s",&starttime);
   avomega      = dp.getTruthRef().average_omega.numerical_value_in(Hz); // quantity<Hz>
   mytree->SetBranchAddress("truth_avomega_Hz",&avomega);
   beatf        = dp.getTruthRef().beat_frequency.numerical_value_in(Hz); // quantity<Hz>
@@ -77,6 +81,8 @@ void WriterDigiToRoot::operator()(DataPack dp)
   mytree->SetBranchAddress("vertex_kinenergy_eV",&kEnergy);
   pangle  = dp.getTruthRef().vertex.pitchangle.numerical_value_in(deg); // quantity<deg>
   mytree->SetBranchAddress("vertex_pitchangle_deg",&pangle);
+  trackHistory  = dp.getTruthRef().vertex.trackHistory; // vector<int>
+  mytree->SetBranchAddress("vertex_trackHistory",&trackHistory);
   // experiment
   gain  = dp.getExperimentRef().gain;
   mytree->SetBranchAddress("digi_gain",&gain);

--- a/modules/writeHitDigiToHDF5.cpp
+++ b/modules/writeHitDigiToHDF5.cpp
@@ -69,7 +69,12 @@ void WriterHitDigiToHDF5::operator()(DataPack dp)
   recordgr.createAttribute("truth_avomega_Hz", dp.getTruthRef().average_omega.numerical_value_in(Hz));
   recordgr.createAttribute("truth_beatf_Hz", dp.getTruthRef().beat_frequency.numerical_value_in(Hz));
   recordgr.createAttribute("truth_chirp_Hz_s", dp.getTruthRef().chirp_rate.numerical_value_in(Hz/s));
+  recordgr.createAttribute("truth_starttime_s", dp.getTruthRef().start_time.numerical_value_in(s));
 
+  if (! dp.getTruthRef().vertex.trackHistory.empty())
+    for (int val : dp.getTruthRef().vertex.trackHistory) trackHistory.push_back(val);
+  recordgr.createDataSet("vertex_trackHistory",trackHistory); // vector<int>
+    
   if (! dp.hitsRef().empty()) { // there are hits to store
     // extract hit data
     for (hit_t hit : dp.hitsRef()) { // get hit struct from vector<hit_t>
@@ -91,6 +96,7 @@ void WriterHitDigiToHDF5::operator()(DataPack dp)
     hitgr.createDataSet("hit_posttheta_deg",hitposttheta); // vector<double>
 
     // clear internal
+    trackHistory.clear();
     hittrID.clear();
     hitx.clear();
     hity.clear();

--- a/modules/writeHitDigiToHDF5.cpp
+++ b/modules/writeHitDigiToHDF5.cpp
@@ -4,11 +4,10 @@
 // std
 #include <iostream>
 #include <string>
-#include <algorithm>
 
 // us
 #include "writeHitDigiToHDF5.hh"
-#include "types.hh"
+
 
 WriterHitDigiToHDF5::WriterHitDigiToHDF5(HighFive::Group& gr) : 
   simgroup(gr)

--- a/modules/writeHitDigiToRoot.cpp
+++ b/modules/writeHitDigiToRoot.cpp
@@ -3,8 +3,6 @@
 
 // std
 #include <iostream>
-#include <algorithm>
-#include <memory>
 
 // us
 #include "writeHitDigiToRoot.hh"

--- a/modules/writeHitDigiToRoot.cpp
+++ b/modules/writeHitDigiToRoot.cpp
@@ -24,6 +24,7 @@ WriterHitDigiToRoot::WriterHitDigiToRoot(TTree* tr, int na) :
   mytree->Branch("truth_nantenna",&nant,"truth_nantenna/I");
   mytree->Branch("truth_snratio",&snratio,"truth_snratio/D");
   mytree->Branch("truth_samplingtime_s",&samplingtime,"truth_samplingtime/D");
+  mytree->Branch("truth_starttime_s",&starttime,"truth_starttime/D");
   mytree->Branch("truth_avomega_Hz",&avomega,"truth_avomega/D");
   mytree->Branch("truth_beatf_Hz",&beatf,"truth_beatf/D");
   mytree->Branch("truth_chirp_Hz_s",&chirprate,"truth_chirp_rate/D");
@@ -35,6 +36,7 @@ WriterHitDigiToRoot::WriterHitDigiToRoot(TTree* tr, int na) :
   mytree->Branch("vertex_posz_m",&posz,"vertex_posz/D");
   mytree->Branch("vertex_kinenergy_eV",&kEnergy,"vertex_kinenergy/D");
   mytree->Branch("vertex_pitchangle_deg",&pangle,"vertex_pitchangle/D");
+  mytree->Branch("vertex_trackHistory",&trackHistory);
   mytree->Branch("digi_gain",&gain,"digi_gain/D");
   mytree->Branch("digi_tfrequency_Hz",&tfrequency,"digi_tfrequency/D");
   mytree->Branch("digi_samplingrate_Hz",&digisamplingrate,"digi_samplingrate/D");
@@ -68,6 +70,8 @@ void WriterHitDigiToRoot::operator()(DataPack dp)
   mytree->SetBranchAddress("truth_snratio",&snratio);
   samplingtime = dp.getTruthRef().sampling_time.numerical_value_in(s); // from quantity<ns> no unit for output
   mytree->SetBranchAddress("truth_samplingtime_s",&samplingtime);
+  starttime = dp.getTruthRef().start_time.numerical_value_in(s); // from quantity<ns> no unit for output
+  mytree->SetBranchAddress("truth_starttime_s",&starttime);
   avomega      = dp.getTruthRef().average_omega.numerical_value_in(Hz); // quantity<Hz>
   mytree->SetBranchAddress("truth_avomega_Hz",&avomega);
   beatf        = dp.getTruthRef().beat_frequency.numerical_value_in(Hz); // quantity<Hz>
@@ -91,6 +95,8 @@ void WriterHitDigiToRoot::operator()(DataPack dp)
   mytree->SetBranchAddress("vertex_kinenergy_eV",&kEnergy);
   pangle  = dp.getTruthRef().vertex.pitchangle.numerical_value_in(deg); // quantity<deg>
   mytree->SetBranchAddress("vertex_pitchangle_deg",&pangle);
+  trackHistory  = dp.getTruthRef().vertex.trackHistory; // vector<int>
+  mytree->SetBranchAddress("vertex_trackHistory",&trackHistory);
   // experiment
   gain  = dp.getExperimentRef().gain;
   mytree->SetBranchAddress("digi_gain",&gain);

--- a/modules/writeWfmToRoot.cpp
+++ b/modules/writeWfmToRoot.cpp
@@ -2,12 +2,10 @@
 
 // std
 #include <iostream>
-#include <algorithm>
-#include <memory>
 
 // us
 #include "writeWfmToRoot.hh"
-#include "types.hh"
+
 
 WriterWfmToRoot::WriterWfmToRoot(std::string inkey, TTree* tr, int na) : 
   inkey(std::move(inkey)),

--- a/modules/writeWfmToRoot.cpp
+++ b/modules/writeWfmToRoot.cpp
@@ -33,6 +33,7 @@ WriterWfmToRoot::WriterWfmToRoot(std::string inkey, TTree* tr, int na) :
   mytree->Branch("vertex_posz_m",&posz,"vertex_posz/D");
   mytree->Branch("vertex_kinenergy_eV",&kEnergy,"vertex_kinenergy/D");
   mytree->Branch("vertex_pitchangle_deg",&pangle,"vertex_pitchangle/D");
+  mytree->Branch("vertex_trackHistory",&trackHistory);
   std::string brname;
   for (int i=0;i<nantenna;++i) {
     brname = "sampled_" + std::to_string(i) + "_V"; // unit in name
@@ -82,6 +83,8 @@ void WriterWfmToRoot::operator()(DataPack dp)
   mytree->SetBranchAddress("vertex_kinenergy_eV",&kEnergy);
   pangle  = dp.getTruthRef().vertex.pitchangle.numerical_value_in(deg); // quantity<deg>
   mytree->SetBranchAddress("vertex_pitchangle_deg",&pangle);
+  trackHistory  = dp.getTruthRef().vertex.trackHistory; // vector<int>
+  mytree->SetBranchAddress("vertex_trackHistory",&trackHistory);
 
   Event<std::any> indata = dp.getRef()[inkey];
   std::string brname;

--- a/modules/writeWfmToRoot.cpp
+++ b/modules/writeWfmToRoot.cpp
@@ -21,6 +21,7 @@ WriterWfmToRoot::WriterWfmToRoot(std::string inkey, TTree* tr, int na) :
   // can now point branch at dummy addresses; makes header only
   mytree->Branch("truth_nantenna",&nantenna,"truth_nantenna/I");
   mytree->Branch("truth_samplingtime_s",&samplingtime,"truth_samplingtime/D");
+  mytree->Branch("truth_starttime_s",&starttime,"truth_starttime/D");
   mytree->Branch("truth_avomega_Hz",&avomega,"truth_avomega/D");
   mytree->Branch("truth_beatf_Hz",&beatf,"truth_beatf/D");
   mytree->Branch("truth_chirp_Hz_s",&chirprate,"truth_chirp_rate/D");
@@ -56,6 +57,8 @@ void WriterWfmToRoot::operator()(DataPack dp)
   mytree->SetBranchAddress("truth_nantenna",&nantenna);
   samplingtime = dp.getTruthRef().sampling_time.numerical_value_in(s); // from quantity<ns> no unit for output
   mytree->SetBranchAddress("truth_samplingtime_s",&samplingtime);
+  starttime = dp.getTruthRef().start_time.numerical_value_in(s); // from quantity<ns> no unit for output
+  mytree->SetBranchAddress("truth_starttime_s",&starttime);
   avomega      = dp.getTruthRef().average_omega.numerical_value_in(Hz); // quantity<Hz>
   mytree->SetBranchAddress("truth_avomega_Hz",&avomega);
   beatf        = dp.getTruthRef().beat_frequency.numerical_value_in(Hz); // quantity<Hz>

--- a/modules/writeWfmToRoot.cpp
+++ b/modules/writeWfmToRoot.cpp
@@ -1,0 +1,124 @@
+// Root waveform Writer module implementation
+// writing a single value; expand for specific outputs.
+
+// std
+#include <iostream>
+#include <algorithm>
+#include <memory>
+
+// us
+#include "writeWfmToRoot.hh"
+#include "types.hh"
+
+WriterWfmToRoot::WriterWfmToRoot(TTree* tr, int na) : 
+  mytree(tr),
+  nantenna(na)
+{
+  // N antennae, one for each waveform; need to know at construction for writing
+  // construct scopedata entries
+  for (int i=0;i<nantenna;++i) {
+    vec_t* p;
+    purewave.push_back(p); // vector in purewave initialized
+  }
+  // can now point branch at dummy addresses; makes header only
+  mytree->Branch("truth_nantenna",&nant,"truth_nantenna/I");
+  mytree->Branch("truth_samplingtime_s",&samplingtime,"truth_samplingtime/D");
+  mytree->Branch("truth_avomega_Hz",&avomega,"truth_avomega/D");
+  mytree->Branch("truth_beatf_Hz",&beatf,"truth_beatf/D");
+  mytree->Branch("truth_chirp_Hz_s",&chirprate,"truth_chirp_rate/D");
+  mytree->Branch("truth_bfield_T",&bfield,"truth_bfield/D");
+  mytree->Branch("vertex_evID",&evID,"vertex_evID/I");
+  mytree->Branch("vertex_trackID",&trID,"vertex_trackID/I");
+  mytree->Branch("vertex_posx_m",&posx,"vertex_posx/D");
+  mytree->Branch("vertex_posy_m",&posy,"vertex_posy/D");
+  mytree->Branch("vertex_posz_m",&posz,"vertex_posz/D");
+  mytree->Branch("vertex_kinenergy_eV",&kEnergy,"vertex_kinenergy/D");
+  mytree->Branch("vertex_pitchangle_deg",&pangle,"vertex_pitchangle/D");
+  for (int i=0;i<nantenna;++i) {
+    brname = "pure_" + std::to_string(i) + "_V"; // unit in name
+    mytree->Branch(brname.data(), &purewave.at(i)); // point to vec_t dummy address
+  }
+  // hit data
+  mytree->Branch("hit_eventID", &hitevID); // point to vec<int>* dummy address
+  mytree->Branch("hit_trackID", &hittrID); // point to vec<int>* dummy address
+  mytree->Branch("hit_locx_m", &hitx); // point to vec<double>* dummy address
+  mytree->Branch("hit_locy_m", &hity); // point to vec<double>* dummy address
+  mytree->Branch("hit_locz_m", &hitz); // point to vec<double>* dummy address
+  mytree->Branch("hit_time_ns", &hittime); // point to vec<double>* dummy address
+  mytree->Branch("hit_edep_eV", &hitedep); // point to vec<double>* dummy address
+  mytree->Branch("hit_posttheta_deg", &hitposttheta); // point to vec<double>* dummy address
+
+}
+
+
+void WriterHitDigiToRoot::operator()(DataPack dp)
+{
+  // extract from datapack and assign to output branch variables with the correct address
+  nant    = dp.getTruthRef().nantenna;
+  mytree->SetBranchAddress("truth_nantenna",&nant);
+  samplingtime = dp.getTruthRef().sampling_time.numerical_value_in(s); // from quantity<ns> no unit for output
+  mytree->SetBranchAddress("truth_samplingtime_s",&samplingtime);
+  avomega      = dp.getTruthRef().average_omega.numerical_value_in(Hz); // quantity<Hz>
+  mytree->SetBranchAddress("truth_avomega_Hz",&avomega);
+  beatf        = dp.getTruthRef().beat_frequency.numerical_value_in(Hz); // quantity<Hz>
+  mytree->SetBranchAddress("truth_beatf_Hz",&beatf);
+  chirprate    = dp.getTruthRef().chirp_rate.numerical_value_in(Hz/s); // quantity<Hz>
+  mytree->SetBranchAddress("truth_chirp_Hz_s",&chirprate);
+  bfield       = dp.getTruthRef().bfield.numerical_value_in(T); // quantity<Hz>
+  mytree->SetBranchAddress("truth_bfield_T",&bfield);
+  // vertex
+  evID = dp.getTruthRef().vertex.eventID;
+  mytree->SetBranchAddress("vertex_evID",&evID);
+  trID = dp.getTruthRef().vertex.trackID;
+  mytree->SetBranchAddress("vertex_trackID",&trID);
+  posx    = dp.getTruthRef().vertex.posx.numerical_value_in(m); // quantity<m>
+  mytree->SetBranchAddress("vertex_posx_m",&posx);
+  posy    = dp.getTruthRef().vertex.posy.numerical_value_in(m); // quantity<m>
+  mytree->SetBranchAddress("vertex_posy_m",&posy);
+  posz    = dp.getTruthRef().vertex.posz.numerical_value_in(m); // quantity<m>
+  mytree->SetBranchAddress("vertex_posz_m",&posz);
+  kEnergy = dp.getTruthRef().vertex.kineticenergy.numerical_value_in(eV); // quantity<eV>
+  mytree->SetBranchAddress("vertex_kinenergy_eV",&kEnergy);
+  pangle  = dp.getTruthRef().vertex.pitchangle.numerical_value_in(deg); // quantity<deg>
+  mytree->SetBranchAddress("vertex_pitchangle_deg",&pangle);
+
+  std::string brname;
+  for (int i=0;i<nantenna;++i) {
+    purewave.at(i) = &dp.getTruthRef().pure.at(i); // vec_t*, copy
+    // store
+    brname = "pure_" + std::to_string(i) + "_V"; // unit in name
+    mytree->SetBranchAddress(brname.data(), &purewave.at(i));
+  }
+  if (! dp.hitsRef().empty()) { // there are hits to store
+    // extract hit data
+    for (hit_t hit : dp.hitsRef()) { // get hit struct from vector<hit_t>
+      hitevID->push_back(hit.eventID);
+      hittrID->push_back(hit.trackID);
+      hitx->push_back(hit.locx.numerical_value_in(m)); // no unit in root file
+      hity->push_back(hit.locy.numerical_value_in(m));
+      hitz->push_back(hit.locz.numerical_value_in(m));
+      hitedep->push_back(hit.edeposit.numerical_value_in(eV));
+      hittime->push_back(hit.timestamp.numerical_value_in(ns));
+      hitposttheta->push_back(hit.anglepost.numerical_value_in(deg));
+    }
+    mytree->SetBranchAddress("hit_eventID", &hitevID); // point to vec<int>* real address
+    mytree->SetBranchAddress("hit_trackID", &hittrID); // point to vec<int>* real address
+    mytree->SetBranchAddress("hit_locx_m", &hitx); // point to vec<double>* real address
+    mytree->SetBranchAddress("hit_locy_m", &hity); // point to vec<double>* real address
+    mytree->SetBranchAddress("hit_locz_m", &hitz); // point to vec<double>* real address
+    mytree->SetBranchAddress("hit_time_ns", &hittime); // point to vec<double>* real address
+    mytree->SetBranchAddress("hit_edep_eV", &hitedep); // point to vec<double>* real address
+    mytree->SetBranchAddress("hit_posttheta_deg", &hitposttheta); // point to vec<double>* real address
+  }
+  // all output collected, write it
+  mytree->Fill();
+  // clear internal
+  hitevID->clear();
+  hittrID->clear();
+  hitx->clear();
+  hity->clear();
+  hitz->clear();
+  hittime->clear();
+  hitedep->clear();
+  hitposttheta->clear();
+}

--- a/modules/writeWfmToRoot.cpp
+++ b/modules/writeWfmToRoot.cpp
@@ -83,7 +83,7 @@ void WriterWfmToRoot::operator()(DataPack dp)
   mytree->SetBranchAddress("vertex_kinenergy_eV",&kEnergy);
   pangle  = dp.getTruthRef().vertex.pitchangle.numerical_value_in(deg); // quantity<deg>
   mytree->SetBranchAddress("vertex_pitchangle_deg",&pangle);
-  trackHistory  = dp.getTruthRef().vertex.trackHistory; // vector<int>
+  trackHistory  = &dp.getTruthRef().vertex.trackHistory; // vector<int>
   mytree->SetBranchAddress("vertex_trackHistory",&trackHistory);
 
   Event<std::any> indata = dp.getRef()[inkey];

--- a/modules/writeWfmToRoot.cpp
+++ b/modules/writeWfmToRoot.cpp
@@ -34,7 +34,7 @@ WriterWfmToRoot::WriterWfmToRoot(std::string inkey, TTree* tr, int na) :
   mytree->Branch("vertex_pitchangle_deg",&pangle,"vertex_pitchangle/D");
   std::string brname;
   for (int i=0;i<nantenna;++i) {
-    brname = "sampled_" + std::to_string(i) + "_[V]"; // unit in name
+    brname = "sampled_" + std::to_string(i) + "_V"; // unit in name
     mytree->Branch(brname.data(), &purewave.at(i)); // point to vec_t dummy address
   }
   // hit data
@@ -50,7 +50,7 @@ WriterWfmToRoot::WriterWfmToRoot(std::string inkey, TTree* tr, int na) :
 }
 
 
-void WriterHitDigiToRoot::operator()(DataPack dp)
+void WriterWfmToRoot::operator()(DataPack dp)
 {
   // extract from datapack and assign to output branch variables with the correct address
   mytree->SetBranchAddress("truth_nantenna",&nantenna);
@@ -84,8 +84,9 @@ void WriterHitDigiToRoot::operator()(DataPack dp)
   std::string brname;
   for (int i=0;i<nantenna;++i) {
     // store
-    brname = "sampled_" + std::to_string(i) + "_[V]"; // unit in name
-    purewave.at(i) = &std::any_cast<vec_t>(indata[brname]); // vec_t*, copy
+    brname = "sampled_" + std::to_string(i) + "_V"; // unit in name
+    vec_t dummy = std::any_cast<vec_t>(indata[brname]); // construct first
+    purewave.at(i) = &dummy; // vec_t*, copy
     mytree->SetBranchAddress(brname.data(), &purewave.at(i));
   }
   if (! dp.hitsRef().empty()) { // there are hits to store

--- a/modules/x2CsvWriter.cpp
+++ b/modules/x2CsvWriter.cpp
@@ -6,7 +6,6 @@
 
 // us
 #include "x2CsvWriter.hh"
-#include "types.hh"
 
 x2CsvWriter::x2CsvWriter(std::ofstream& ofs, std::string in, std::string l21, std::string l22) : 
     inkey(std::move(in)),

--- a/modules/xCsvWriter.cpp
+++ b/modules/xCsvWriter.cpp
@@ -6,7 +6,6 @@
 
 // us
 #include "xCsvWriter.hh"
-#include "types.hh"
 
 xCsvWriter::xCsvWriter(std::ofstream& ofs, std::string in, std::string l2) : 
     inkey(std::move(in)),

--- a/src/trackMerger.cpp
+++ b/src/trackMerger.cpp
@@ -1,0 +1,57 @@
+// ------------------------------------
+// trackMerger methods implementation
+
+// std
+#include <algorithm>
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+
+// us
+#include "trackMerger.hh"
+
+trackMerger::trackMerger(TTreeReader& re, int na) : 
+  nant(na),
+  prevID(-1),
+  reader(re)
+    nantenna(reader, "truth_nantenna"),
+    eventID(reader, "vertex_evID"), // needs reader by reference
+    trackID(reader, "vertex_trackID"),
+    hitevID(reader, "hit_eventID"), // interaction data
+    hittrID(reader, "hit_trackID"),
+    hitedep(reader, "hit_edep_eV"), 
+    hittime(reader, "hit_time_ns"),
+    hitposttheta(reader, "hit_posttheta_deg"),
+    hitx(reader, "hit_locx_m"), // interaction location
+    hity(reader, "hit_locy_m"),
+    hitz(reader, "hit_locz_m"),
+    posx(reader, "vertex_posx_m"), // vertex data
+    posy(reader, "vertex_posy_m"),
+    posz(reader, "vertex_posz_m"),
+    kEnergy(reader, "vertex_kinenergy_eV"),
+    pangle(reader, "vertex_pitchangle_deg"),
+    samplingtime(reader, "truth_samplingtime_s"),
+    starttime(reader, "truth_starttime_s"),
+    avomega(reader, "truth_avomega_Hz"),
+    beatf(reader, "truth_beatf_Hz"),
+    chirprate(reader, "truth_chirp_Hz_s"),
+    bfield(reader, "truth_bfield_T")
+{
+  // int nant for n antenna is needed at construction time
+  std::string brname;
+  for (int i=0;i<nant;++i) {
+    brname = "sampled_" + std::to_string(i) + "_V";
+    wfmarray.emplace_back(reader, brname.data());
+  }
+  std::cout << "in reader n entries: " << reader.GetEntries() << std::endl;
+}
+
+
+DataPack trackMerger::read()
+{
+}
+
+
+vec_t trackMerger::add(vec_t& signal, double mtime, vec_t& other)
+{
+}

--- a/src/trackMerger.cpp
+++ b/src/trackMerger.cpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <functional>
 #include <iostream>
-#include <stdexcept>
+#include <cmath>
 
 // us
 #include "trackMerger.hh"
@@ -142,9 +142,8 @@ void trackMerger::Loop()
       for (int i=0;i<nant;++i) {
 	vec_t wfm(wfmarray.at(i).begin(), wfmarray.at(i).end()); // new wfm
 	add(wfm, i); // add new wfm to previous using localStart and localWfm
-      }
-      // assign values to DataPack to be written out separately.
-      for (int i=0;i<nant;++i) {
+
+	// assign values to DataPack to be written out separately.
 	brname = "sampled_" + std::to_string(i) + "_V";
 	outdata[brname] = std::make_any<vec_t>(localWfm.at(i)); // merged is in localWfm
       }
@@ -154,6 +153,7 @@ void trackMerger::Loop()
       mergedDP.getTruthRef().vertex.trackHistory = *trackHistory; // vector<int>
     }
   }
+  std::cout << "Loop finished." << std::endl;
 }
 
 
@@ -295,13 +295,13 @@ void trackMerger::writeRow(DataPack dp)
 void trackMerger::add(vec_t& other, int whichAntenna)
 {
   // resize localWfm to fit the merger.
-  int idx_start = (int)(localStart / localSampling); // find entry index for adding
+  int idx_start = (int)std::lround(localStart / localSampling); // find entry index for adding
   int final_idx = localWfm.at(whichAntenna).size() - 1;
   int end_other = other.size() - 1;
   int final_other = idx_start + end_other;
   int diff = final_other - final_idx;
-  if (diff > 0) localWfm.at(whichAntenna).resize(final_idx+diff+1);
+  if (diff > 0) localWfm.at(whichAntenna).resize(final_idx+diff+2);
   // action
-  // std::transform(other.begin(), other.end(), localWfm.at(whichAntenna).begin()+idx_start
-  //                localWfm.at(whichAntenna).begin()+idx_start, std::plus<double>()); // in-place addition
+  std::transform(other.begin(), other.end(), localWfm.at(whichAntenna).begin()+idx_start
+		 localWfm.at(whichAntenna).begin()+idx_start, std::plus<double>()); // in-place addition
 }

--- a/src/trackMerger.cpp
+++ b/src/trackMerger.cpp
@@ -14,28 +14,28 @@ trackMerger::trackMerger(TTreeReader& re, int na) :
   nant(na),
   prevID(-1),
   reader(re)
-    nantenna(reader, "truth_nantenna"),
-    eventID(reader, "vertex_evID"), // needs reader by reference
-    trackID(reader, "vertex_trackID"),
-    hitevID(reader, "hit_eventID"), // interaction data
-    hittrID(reader, "hit_trackID"),
-    hitedep(reader, "hit_edep_eV"), 
-    hittime(reader, "hit_time_ns"),
-    hitposttheta(reader, "hit_posttheta_deg"),
-    hitx(reader, "hit_locx_m"), // interaction location
-    hity(reader, "hit_locy_m"),
-    hitz(reader, "hit_locz_m"),
-    posx(reader, "vertex_posx_m"), // vertex data
-    posy(reader, "vertex_posy_m"),
-    posz(reader, "vertex_posz_m"),
-    kEnergy(reader, "vertex_kinenergy_eV"),
-    pangle(reader, "vertex_pitchangle_deg"),
-    samplingtime(reader, "truth_samplingtime_s"),
-    starttime(reader, "truth_starttime_s"),
-    avomega(reader, "truth_avomega_Hz"),
-    beatf(reader, "truth_beatf_Hz"),
-    chirprate(reader, "truth_chirp_Hz_s"),
-    bfield(reader, "truth_bfield_T")
+  nantenna(reader, "truth_nantenna"),
+  eventID(reader, "vertex_evID"), // needs reader by reference
+  trackID(reader, "vertex_trackID"),
+  hitevID(reader, "hit_eventID"), // interaction data
+  hittrID(reader, "hit_trackID"),
+  hitedep(reader, "hit_edep_eV"), 
+  hittime(reader, "hit_time_ns"),
+  hitposttheta(reader, "hit_posttheta_deg"),
+  hitx(reader, "hit_locx_m"), // interaction location
+  hity(reader, "hit_locy_m"),
+  hitz(reader, "hit_locz_m"),
+  posx(reader, "vertex_posx_m"), // vertex data
+  posy(reader, "vertex_posy_m"),
+  posz(reader, "vertex_posz_m"),
+  kEnergy(reader, "vertex_kinenergy_eV"),
+  pangle(reader, "vertex_pitchangle_deg"),
+  samplingtime(reader, "truth_samplingtime_s"),
+  starttime(reader, "truth_starttime_s"),
+  avomega(reader, "truth_avomega_Hz"),
+  beatf(reader, "truth_beatf_Hz"),
+  chirprate(reader, "truth_chirp_Hz_s"),
+  bfield(reader, "truth_bfield_T")
 {
   // int nant for n antenna is needed at construction time
   std::string brname;
@@ -47,8 +47,63 @@ trackMerger::trackMerger(TTreeReader& re, int na) :
 }
 
 
-DataPack trackMerger::read()
+DataPack trackMerger::readRow()
 {
+  // protection against and of file must come from outside.
+  Event_map<std::any> eventmap; // data item for delivery
+  Event<std::any> outdata; // to hold all the data items from file
+  
+  // collect all trajectory info from file, reader holds event iterator
+  // std::cout << "reader called" << std::endl;
+  std::string brname;
+  reader.Next()
+    for (int i=0;i<nant;++i) {
+      brname = "sampled_" + std::to_string(i) + "_V";
+      vec_t wfm(wfmarray.at(i).begin(), wfmarray.at(i).end());
+      outdata[brname] = std::make_any<vec_t>(wfm);
+      localWfm.push_back(wfm); // local copy for potential merging
+    }
+  eventmap[outkey] = outdata; // with outdata an Event<std::any>
+
+  // make data product, full copy of in from file.
+  // at the end, store new data product in dictionary event map.
+  DataPack dp(eventmap);
+  // fill truth struct with vertex info, restore units from branch names
+  dp.getTruthRef().vertex.eventID = *eventID;
+  prevID = *eventID; // local copy
+  dp.getTruthRef().vertex.trackID = *trackID;
+  prevTrackID = *trackID;
+  dp.getTruthRef().vertex.posx = *posx * m;
+  dp.getTruthRef().vertex.posy = *posy * m;
+  dp.getTruthRef().vertex.posz = *posz * m;
+  dp.getTruthRef().vertex.kineticenergy = *kEnergy * eV;
+  dp.getTruthRef().vertex.pitchangle = *pangle * deg;
+  
+  // check on hits, separately from trajectory reader
+  // the hit reader may or may not hold data.
+  if (! hitevID->empty()) {
+    for (unsigned int j=0;j<hitevID->size();++j) {
+      dp.getHitRef().eventID   = hitevID->at(j);
+      dp.getHitRef().trackID   = hittrID->at(j);
+      dp.getHitRef().edeposit  = hitedep->at(j) * eV;
+      dp.getHitRef().timestamp = hittime->at(j) * ns;
+      dp.getHitRef().anglepost = hitposttheta->at(j) * deg;
+      dp.getHitRef().locx = hitx->at(j) * m;
+      dp.getHitRef().locy = hity->at(j) * m;
+      dp.getHitRef().locz = hitz->at(j) * m;
+      // store the filled hit_t
+      dp.hitsRef().push_back(dp.getHit());
+    }
+  }
+  dp.getTruthRef().nantenna = *nantenna; // store input truth
+  dp.getTruthRef().chirp_rate = *chirprate * Hz/s; // store input truth
+  dp.getTruthRef().beat_frequency = *beatf * Hz; // store input truth
+  dp.getTruthRef().average_omega = *avomega * Hz; // store input truth
+  dp.getTruthRef().sampling_time = *samplingtime * s; // store input truth
+  dp.getTruthRef().start_time = *starttime * s; // store input truth
+  localStart = *starttime; // local copy, unit [s] implicit
+  dp.getTruthRef().bfield = *bfield * T; // store input truth
+  return dp;
 }
 
 

--- a/src/trackMerger.cpp
+++ b/src/trackMerger.cpp
@@ -10,10 +10,11 @@
 // us
 #include "trackMerger.hh"
 
-trackMerger::trackMerger(TTreeReader& re, int na) : 
+trackMerger::trackMerger(TTreeReader& re, TTree* tr, int na) : 
   nant(na),
   prevID(-1),
-  reader(re)
+  reader(re),
+  mytree(tr)
   nantenna(reader, "truth_nantenna"),
   eventID(reader, "vertex_evID"), // needs reader by reference
   trackID(reader, "vertex_trackID"),
@@ -44,6 +45,50 @@ trackMerger::trackMerger(TTreeReader& re, int na) :
     wfmarray.emplace_back(reader, brname.data());
   }
   std::cout << "in reader n entries: " << reader.GetEntries() << std::endl;
+
+  // prepare writer structure
+  // N antennae, one for each waveform; need to know at construction for writing
+  // construct scopedata entries
+  for (int i=0;i<nant;++i) {
+    vec_t* p;
+    purewave.push_back(p); // vector in purewave initialized
+  }
+  // can now point branch at dummy addresses; makes header only
+  mytree->Branch("truth_nantenna",&nant,"truth_nantenna/I");
+  mytree->Branch("truth_samplingtime_s",&samplingtimeOut,"truth_samplingtime/D");
+  mytree->Branch("truth_starttime_s",&starttimeOut,"truth_starttime/D");
+  mytree->Branch("truth_avomega_Hz",&avomegaOut,"truth_avomega/D");
+  mytree->Branch("truth_beatf_Hz",&beatfOut,"truth_beatf/D");
+  mytree->Branch("truth_chirp_Hz_s",&chirprateOut,"truth_chirp_rate/D");
+  mytree->Branch("truth_bfield_T",&bfieldOut,"truth_bfield/D");
+  mytree->Branch("vertex_evID",&evID,"vertex_evID/I");
+  mytree->Branch("vertex_trackID",&trID,"vertex_trackID/I");
+  mytree->Branch("vertex_posx_m",&posxOut,"vertex_posx/D");
+  mytree->Branch("vertex_posy_m",&posyOut,"vertex_posy/D");
+  mytree->Branch("vertex_posz_m",&poszOut,"vertex_posz/D");
+  mytree->Branch("vertex_kinenergy_eV",&kEnergyOut,"vertex_kinenergy/D");
+  mytree->Branch("vertex_pitchangle_deg",&pangleOut,"vertex_pitchangle/D");
+  mytree->Branch("vertex_trackHistory",&trackHistory); // mader in Merger
+  for (int i=0;i<nant;++i) {
+    brname = "sampled_" + std::to_string(i) + "_V"; // unit in name
+    mytree->Branch(brname.data(), &purewave.at(i)); // point to vec_t dummy address
+  }
+  // hit data
+  mytree->Branch("hit_eventID", &hitevIDOut); // point to vec<int>* dummy address
+  mytree->Branch("hit_trackID", &hittrIDOut); // point to vec<int>* dummy address
+  mytree->Branch("hit_locx_m", &hitxOut); // point to vec<double>* dummy address
+  mytree->Branch("hit_locy_m", &hityOut); // point to vec<double>* dummy address
+  mytree->Branch("hit_locz_m", &hitzOut); // point to vec<double>* dummy address
+  mytree->Branch("hit_time_ns", &hittimeOut); // point to vec<double>* dummy address
+  mytree->Branch("hit_edep_eV", &hitedepOut); // point to vec<double>* dummy address
+  mytree->Branch("hit_posttheta_deg", &hitpostthetaOut); // point to vec<double>* dummy address
+
+  std::cout << "in merger, TTree set up." << std::endl;
+}
+
+
+void trackMerger::Loop()
+{
 }
 
 
@@ -56,14 +101,15 @@ DataPack trackMerger::readRow()
   // collect all trajectory info from file, reader holds event iterator
   // std::cout << "reader called" << std::endl;
   std::string brname;
-  reader.Next()
-    for (int i=0;i<nant;++i) {
-      brname = "sampled_" + std::to_string(i) + "_V";
-      vec_t wfm(wfmarray.at(i).begin(), wfmarray.at(i).end());
-      outdata[brname] = std::make_any<vec_t>(wfm);
-      localWfm.push_back(wfm); // local copy for potential merging
-    }
-  eventmap[outkey] = outdata; // with outdata an Event<std::any>
+  reader.Next();
+  // local storage
+  for (int i=0;i<nant;++i) {
+    brname = "sampled_" + std::to_string(i) + "_V";
+    vec_t wfm(wfmarray.at(i).begin(), wfmarray.at(i).end());
+    outdata[brname] = std::make_any<vec_t>(wfm);
+    localWfm.push_back(wfm); // local copy for potential merging
+  }
+  eventmap["internal"] = outdata; // with outdata an Event<std::any>
 
   // make data product, full copy of in from file.
   // at the end, store new data product in dictionary event map.
@@ -107,6 +153,83 @@ DataPack trackMerger::readRow()
 }
 
 
-vec_t trackMerger::add(vec_t& signal, double mtime, vec_t& other)
+void trackMerger::writeRow(DataPack dp)
+{
+  // extract from datapack and assign to output branch variables with the correct address
+  mytree->SetBranchAddress("truth_nantenna",&nantenna);
+  samplingtimeOut = dp.getTruthRef().sampling_time.numerical_value_in(s); // from quantity<ns> no unit for output
+  mytree->SetBranchAddress("truth_samplingtime_s",&samplingtimeOut);
+  starttimeOut = dp.getTruthRef().start_time.numerical_value_in(s); // from quantity<ns> no unit for output
+  mytree->SetBranchAddress("truth_starttime_s",&starttimeOut);
+  avomegaOut      = dp.getTruthRef().average_omega.numerical_value_in(Hz); // quantity<Hz>
+  mytree->SetBranchAddress("truth_avomega_Hz",&avomegaOut);
+  beatfOut        = dp.getTruthRef().beat_frequency.numerical_value_in(Hz); // quantity<Hz>
+  mytree->SetBranchAddress("truth_beatf_Hz",&beatfOut);
+  chirprateOut    = dp.getTruthRef().chirp_rate.numerical_value_in(Hz/s); // quantity<Hz>
+  mytree->SetBranchAddress("truth_chirp_Hz_s",&chirprateOut);
+  bfieldOut       = dp.getTruthRef().bfield.numerical_value_in(T); // quantity<Hz>
+  mytree->SetBranchAddress("truth_bfield_T",&bfieldOut);
+  // vertex
+  evID = dp.getTruthRef().vertex.eventID;
+  mytree->SetBranchAddress("vertex_evID",&evID);
+  trID = dp.getTruthRef().vertex.trackID;
+  mytree->SetBranchAddress("vertex_trackID",&trID);
+  posxOut    = dp.getTruthRef().vertex.posx.numerical_value_in(m); // quantity<m>
+  mytree->SetBranchAddress("vertex_posx_m",&posxOut);
+  posyOut    = dp.getTruthRef().vertex.posy.numerical_value_in(m); // quantity<m>
+  mytree->SetBranchAddress("vertex_posy_m",&posyOut);
+  poszOut    = dp.getTruthRef().vertex.posz.numerical_value_in(m); // quantity<m>
+  mytree->SetBranchAddress("vertex_posz_m",&poszOut);
+  kEnergyOut = dp.getTruthRef().vertex.kineticenergy.numerical_value_in(eV); // quantity<eV>
+  mytree->SetBranchAddress("vertex_kinenergy_eV",&kEnergyOut);
+  pangleOut  = dp.getTruthRef().vertex.pitchangle.numerical_value_in(deg); // quantity<deg>
+  mytree->SetBranchAddress("vertex_pitchangle_deg",&pangleOut);
+  trackHistory  = dp.getTruthRef().vertex.trackHistory; // vector<int>
+  mytree->SetBranchAddress("vertex_trackHistory",&trackHistory);
+
+  Event<std::any> indata = dp.getRef()["internal"];
+  for (int i=0;i<nantenna;++i) {
+    // store
+    brname = "sampled_" + std::to_string(i) + "_V"; // unit in name
+    vec_t dummy = std::any_cast<vec_t>(indata[brname]); // construct first
+    purewave.at(i) = &dummy; // vec_t*, copy
+    mytree->SetBranchAddress(brname.data(), &purewave.at(i));
+  }
+  if (! dp.hitsRef().empty()) { // there are hits to store
+    // extract hit data
+    for (hit_t hit : dp.hitsRef()) { // get hit struct from vector<hit_t>
+      hitevIDOut->push_back(hit.eventID);
+      hittrIDOut->push_back(hit.trackID);
+      hitxOut->push_back(hit.locx.numerical_value_in(m)); // no unit in root file
+      hityOut->push_back(hit.locy.numerical_value_in(m));
+      hitzOut->push_back(hit.locz.numerical_value_in(m));
+      hitedepOut->push_back(hit.edeposit.numerical_value_in(eV));
+      hittimeOut->push_back(hit.timestamp.numerical_value_in(ns));
+      hitpostthetaOut->push_back(hit.anglepost.numerical_value_in(deg));
+    }
+    mytree->SetBranchAddress("hit_eventID", &hitevIDOut); // point to vec<int>* real address
+    mytree->SetBranchAddress("hit_trackID", &hittrIDOut); // point to vec<int>* real address
+    mytree->SetBranchAddress("hit_locx_m", &hitxOut); // point to vec<double>* real address
+    mytree->SetBranchAddress("hit_locy_m", &hityOut); // point to vec<double>* real address
+    mytree->SetBranchAddress("hit_locz_m", &hitzOut); // point to vec<double>* real address
+    mytree->SetBranchAddress("hit_time_ns", &hittimeOut); // point to vec<double>* real address
+    mytree->SetBranchAddress("hit_edep_eV", &hitedepOut); // point to vec<double>* real address
+    mytree->SetBranchAddress("hit_posttheta_deg", &hitpostthetaOut); // point to vec<double>* real address
+  }
+  // all output collected, write it
+  mytree->Fill();
+  // clear internal
+  hitevIDOut->clear();
+  hittrIDOut->clear();
+  hitxOut->clear();
+  hityOut->clear();
+  hitzOut->clear();
+  hittimeOut->clear();
+  hitedepOut->clear();
+  hitpostthetaOut->clear();
+}
+
+
+void trackMerger::add(vec_t& other)
 {
 }

--- a/src/trackMerger.cpp
+++ b/src/trackMerger.cpp
@@ -214,7 +214,7 @@ DataPack trackMerger::readRow()
 }
 
 
-void trackMerger::writeRow(DataPack dp)
+void trackMerger::writeRow(DataPack& dp)
 {
   // extract from datapack and assign to output branch variables with the correct address
   mytree->SetBranchAddress("truth_nantenna",&nant);


### PR DESCRIPTION
Aim: add feature of merging tracks per event in case of multiple electron trajectories per event.
Required: waveform writer and reader at initial stage since merger cannot run in pipeline (multiple reads  - each track a separate file entry - required).
For testing, make fake G4 output containing trivial 2 waveforms per event, test writer to file mimicking G4 output. That testing file then becomes input to Wfm writer, testing that new module - testing pipeline. Finally, testing of track merger becomes possible, including waveform reader and writer as stand-alone app.
